### PR TITLE
Added Persson's artificial viscosity (AIAA 2006-0112).

### DIFF
--- a/pyfr/solvers/base/elements.py
+++ b/pyfr/solvers/base/elements.py
@@ -269,3 +269,11 @@ class BaseElements(object, metaclass=ABCMeta):
         rcstri = ((self.nfpts, self._vect_fpts.leadsubdim),)*nfp
 
         return (self._vect_fpts.mid,)*nfp, rcmap, rcstri
+
+    def get_avis_fpts_for_inter(self, eidx, fidx):
+        nfp = self.nfacefpts[fidx]
+
+        rcmap = [(fpidx, eidx) for fpidx in self._srtd_face_fpts[fidx][eidx]]
+        cstri = ((self._avis_fpts.leadsubdim,),)*nfp
+
+        return (self._avis_fpts.mid,)*nfp, rcmap, cstri

--- a/pyfr/solvers/base/inters.py
+++ b/pyfr/solvers/base/inters.py
@@ -55,7 +55,7 @@ class BaseInters(object):
 
         return self._be.const_matrix(m)
 
-    def _view(self, inter, meth, vshape):
+    def _view(self, inter, meth, vshape=tuple()):
         vm = _get_inter_objs(inter, meth, self._elemap)
         vm = [np.concatenate(m)[self._perm] for m in zip(*vm)]
         return self._be.view(*vm, vshape=vshape)
@@ -66,7 +66,10 @@ class BaseInters(object):
     def _vect_view(self, inter, meth):
         return self._view(inter, meth, (self.ndims, self.nvars))
 
-    def _xchg_view(self, inter, meth, vshape):
+    def _avis_view(self, inter, meth):
+        return self._view(inter, meth)
+
+    def _xchg_view(self, inter, meth, vshape=tuple()):
         vm = _get_inter_objs(inter, meth, self._elemap)
         vm = [np.concatenate(m)[self._perm] for m in zip(*vm)]
         return self._be.xchg_view(*vm, vshape=vshape)
@@ -76,3 +79,6 @@ class BaseInters(object):
 
     def _vect_xchg_view(self, inter, meth):
         return self._xchg_view(inter, meth, (self.ndims, self.nvars))
+
+    def _avis_xchg_view(self, inter, meth):
+        return self._xchg_view(inter, meth)

--- a/pyfr/solvers/navstokes/elements.py
+++ b/pyfr/solvers/navstokes/elements.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 
+import numpy as np
+
+from pyfr.backends.base.kernels import ComputeMetaKernel
 from pyfr.solvers.baseadvecdiff import BaseAdvectionDiffusionElements
 from pyfr.solvers.euler.elements import BaseFluidElements
+from pyfr.util import ndrange
 
 
 class NavierStokesElements(BaseFluidElements, BaseAdvectionDiffusionElements):
@@ -16,15 +20,88 @@ class NavierStokesElements(BaseFluidElements, BaseAdvectionDiffusionElements):
                        visc_corr=visc_corr,
                        c=self.cfg.items_as('constants', float))
 
+        shock_capturing = self.cfg.get('solver', 'shock-capturing', 'none')
+        if shock_capturing == 'artificial-viscosity':
+            # Allocate required scratch space for artificial viscosity
+            nupts, nfpts, neles = self.nupts, self.nfpts, self.neles
+            tags = {'align'}
+            avis_upts = backend.matrix((nupts, 1, neles), extent='avis_upts',
+                                       tags=tags)
+
+            if nfpts >= nupts:
+                self._avis_fpts = backend.matrix((nfpts, 1, neles),
+                                                 extent='avis_fpts', tags=tags)
+                avis_upts_temp = backend.matrix((nupts, 1, neles),
+                                                aliases=self._avis_fpts,
+                                                tags=tags)
+            else:
+                avis_upts_temp = backend.matrix((nupts, 1, neles),
+                                                extent='avis_fpts', tags=tags)
+                self._avis_fpts = backend.matrix((nfpts, 1, neles),
+                                                 aliases=avis_upts_temp,
+                                                 tags=tags)
+
+            backend.pointwise.register('pyfr.solvers.navstokes.kernels.entropy')
+            backend.pointwise.register('pyfr.solvers.navstokes.kernels.avis')
+
+            def artf_vis():
+                # Compute entropy and save to avis_upts
+                ent = backend.kernel('entropy', tplargs=tplargs,
+                                     dims=[self.nupts, self.neles],
+                                     u=self.scal_upts_inb, s=avis_upts)
+
+                # Compute modal coefficients of entropy
+                rcpvdm = np.linalg.inv(self.basis.ubasis.vdm.T)
+                rcpvdm = self._be.const_matrix(rcpvdm, tags={'align'})
+                mul = backend.kernel('mul', rcpvdm, avis_upts,
+                                     out=avis_upts_temp)
+
+                # Additional constants for element-wise artificial viscosity
+                ubdegs = self.basis.ubasis.degrees
+                tplargs['c'].update(
+                    self.cfg.items_as('solver-artificial-viscosity', float)
+                )
+                tplargs.update(dict(nupts=self.nupts, nfpts=self.nfpts,
+                                    order=self.basis.order, ubdegs=ubdegs))
+
+                # Column view for avis_upts/fpts matrices
+                def col_view(mat):
+                    vshape = (mat.nrow,)
+                    rcmap = np.array(list(ndrange(1, mat.ncol)))
+                    matmap = np.array([mat.mid]*mat.ncol)
+                    stridemap = np.array([[mat.leaddim]]*mat.ncol)
+
+                    return backend.view(matmap, rcmap, stridemap, vshape)
+
+                avis_upts_cv = col_view(avis_upts)
+                avis_fpts_cv = col_view(self._avis_fpts)
+                avis_upts_temp_cv = col_view(avis_upts_temp)
+
+                # Element-wise artificial viscosity kernel
+                avis = backend.kernel('avis', tplargs, dims=[self.neles],
+                                      ubdegs=ubdegs,
+                                      s=avis_upts_temp_cv,
+                                      amu_e=avis_upts_cv, amu_f=avis_fpts_cv)
+
+                return ComputeMetaKernel([ent, mul, avis])
+
+            self.kernels['avis'] = artf_vis
+            tplargs['art_vis'] = 'mu'
+        elif shock_capturing == 'none':
+            avis_upts = None
+            tplargs['art_vis'] = 'none'
+        else:
+            raise ValueError('Invalid shock-capturing option')
+
         if 'flux' in self.antialias:
             self.kernels['tdisf'] = lambda: backend.kernel(
                 'tflux', tplargs=tplargs, dims=[self.nqpts, self.neles],
                 u=self._scal_qpts, smats=self.smat_at('qpts'),
-                f=self._vect_qpts
+                f=self._vect_qpts, amu=avis_upts
             )
         else:
             self.kernels['tdisf'] = lambda: backend.kernel(
                 'tflux', tplargs=tplargs, dims=[self.nupts, self.neles],
                 u=self.scal_upts_inb, smats=self.smat_at('upts'),
-                f=self._vect_upts
+                f=self._vect_upts, amu=avis_upts
             )

--- a/pyfr/solvers/navstokes/inters.py
+++ b/pyfr/solvers/navstokes/inters.py
@@ -2,20 +2,31 @@
 
 import numpy as np
 
+from pyfr.backends.base import NullComputeKernel, NullMPIKernel
 from pyfr.solvers.baseadvecdiff import (BaseAdvectionDiffusionBCInters,
                                         BaseAdvectionDiffusionIntInters,
                                         BaseAdvectionDiffusionMPIInters)
 
 
 class NavierStokesIntInters(BaseAdvectionDiffusionIntInters):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, be, lhs, rhs, elemap, cfg):
+        super().__init__(be, lhs, rhs, elemap, cfg)
 
         # Pointwise template arguments
         rsolver = self.cfg.get('solver-interfaces', 'riemann-solver')
         visc_corr = self.cfg.get('solver', 'viscosity-correction', 'none')
         tplargs = dict(ndims=self.ndims, nvars=self.nvars, rsolver=rsolver,
                        visc_corr=visc_corr, c=self._tpl_c)
+
+        # Generate the additional view matrices for artificial viscosity
+        self.shock_capturing = self.cfg.get('solver', 'shock-capturing', 'none')
+        if self.shock_capturing == 'artificial-viscosity':
+            avis0_lhs = self._avis_view(lhs, 'get_avis_fpts_for_inter')
+            avis0_rhs = self._avis_view(rhs, 'get_avis_fpts_for_inter')
+            tplargs['art_vis'] = 'mu'
+        else:
+            avis0_lhs = avis0_rhs = None
+            tplargs['art_vis'] = 'none'
 
         self._be.pointwise.register('pyfr.solvers.navstokes.kernels.intconu')
         self._be.pointwise.register('pyfr.solvers.navstokes.kernels.intcflux')
@@ -29,20 +40,56 @@ class NavierStokesIntInters(BaseAdvectionDiffusionIntInters):
             'intcflux', tplargs=tplargs, dims=[self.ninterfpts],
             ul=self._scal0_lhs, ur=self._scal0_rhs,
             gradul=self._vect0_lhs, gradur=self._vect0_rhs,
+            amul=avis0_lhs, amur=avis0_rhs,
             magnl=self._mag_pnorm_lhs, magnr=self._mag_pnorm_rhs,
             nl=self._norm_pnorm_lhs
         )
 
 
 class NavierStokesMPIInters(BaseAdvectionDiffusionMPIInters):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, be, lhs, rhsrank, rallocs, elemap, cfg):
+        super().__init__(be, lhs, rhsrank, rallocs, elemap, cfg)
 
         # Pointwise template arguments
         rsolver = self.cfg.get('solver-interfaces', 'riemann-solver')
         visc_corr = self.cfg.get('solver', 'viscosity-correction', 'none')
         tplargs = dict(ndims=self.ndims, nvars=self.nvars, rsolver=rsolver,
                        visc_corr=visc_corr, c=self._tpl_c)
+
+        # Generate the additional kernels, view matrices for artificial viscosity
+        self.shock_capturing = self.cfg.get('solver', 'shock-capturing', 'none')
+        if self.shock_capturing == 'artificial-viscosity':
+            avis0_lhs = self._avis_xchg_view(lhs, 'get_avis_fpts_for_inter')
+            avis0_rhs = be.xchg_matrix_for_view(avis0_lhs)
+
+            # If we need to send our artificial viscosity to the RHS
+            if self._tpl_c['ldg-beta'] != -0.5:
+                self.kernels['avis_fpts_pack'] = lambda: be.kernel(
+                    'pack', avis0_lhs
+                )
+                self.kernels['avis_fpts_send'] = lambda: be.kernel(
+                    'send_pack', avis0_lhs, self._rhsrank, self.MPI_TAG
+                )
+            else:
+                self.kernels['avis_fpts_pack'] = lambda: NullComputeKernel()
+                self.kernels['avis_fpts_send'] = lambda: NullMPIKernel()
+
+            # If we need to recv artificial viscosity from the RHS
+            if self._tpl_c['ldg-beta'] != 0.5:
+                self.kernels['avis_fpts_recv'] = lambda: be.kernel(
+                    'recv_pack', avis0_rhs, self._rhsrank, self.MPI_TAG
+                )
+                self.kernels['avis_fpts_unpack'] = lambda: be.kernel(
+                    'unpack', avis0_rhs
+                )
+            else:
+                self.kernels['avis_fpts_recv'] = lambda: NullMPIKernel()
+                self.kernels['avis_fpts_unpack'] = lambda: NullComputeKernel()
+
+            tplargs['art_vis'] = 'mu'
+        else:
+            avis0_lhs = avis0_rhs = None
+            tplargs['art_vis'] = 'none'
 
         self._be.pointwise.register('pyfr.solvers.navstokes.kernels.mpiconu')
         self._be.pointwise.register('pyfr.solvers.navstokes.kernels.mpicflux')
@@ -55,6 +102,7 @@ class NavierStokesMPIInters(BaseAdvectionDiffusionMPIInters):
             'mpicflux', tplargs=tplargs, dims=[self.ninterfpts],
             ul=self._scal0_lhs, ur=self._scal0_rhs,
             gradul=self._vect0_lhs, gradur=self._vect0_rhs,
+            amul=avis0_lhs, amur=avis0_rhs,
             magnl=self._mag_pnorm_lhs, nl=self._norm_pnorm_lhs
         )
 
@@ -62,8 +110,8 @@ class NavierStokesMPIInters(BaseAdvectionDiffusionMPIInters):
 class NavierStokesBaseBCInters(BaseAdvectionDiffusionBCInters):
     cflux_state = None
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, be, lhs, elemap, cfgsect, cfg):
+        super().__init__(be, lhs, elemap, cfgsect, cfg)
 
         # Pointwise template arguments
         rsolver = self.cfg.get('solver-interfaces', 'riemann-solver')
@@ -71,6 +119,15 @@ class NavierStokesBaseBCInters(BaseAdvectionDiffusionBCInters):
         tplargs = dict(ndims=self.ndims, nvars=self.nvars, rsolver=rsolver,
                        visc_corr=visc_corr, c=self._tpl_c, bctype=self.type,
                        bccfluxstate=self.cflux_state)
+
+        # Generate the additional view matrices for artificial viscosity
+        self.shock_capturing = self.cfg.get('solver', 'shock-capturing', 'none')
+        if self.shock_capturing == 'artificial-viscosity':
+            avis0_lhs = self._avis_view(lhs, 'get_avis_fpts_for_inter')
+            tplargs['art_vis'] = 'mu'
+        else:
+            avis0_lhs = None
+            tplargs['art_vis'] = 'none'
 
         self._be.pointwise.register('pyfr.solvers.navstokes.kernels.bcconu')
         self._be.pointwise.register('pyfr.solvers.navstokes.kernels.bccflux')
@@ -82,7 +139,7 @@ class NavierStokesBaseBCInters(BaseAdvectionDiffusionBCInters):
         )
         self.kernels['comm_flux'] = lambda: self._be.kernel(
             'bccflux', tplargs=tplargs, dims=[self.ninterfpts],
-            ul=self._scal0_lhs, gradul=self._vect0_lhs,
+            ul=self._scal0_lhs, gradul=self._vect0_lhs, amul=avis0_lhs,
             magnl=self._mag_pnorm_lhs, nl=self._norm_pnorm_lhs
         )
 

--- a/pyfr/solvers/navstokes/kernels/avis.mako
+++ b/pyfr/solvers/navstokes/kernels/avis.mako
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+<%inherit file='base'/>
+<%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
+
+<%
+    import math
+    pi = math.pi
+%>
+
+<%pyfr:kernel name='avis' ndim='1'
+              s='out view fpdtype_t[${str(nupts)}]'
+              amu_e='out view fpdtype_t[${str(nupts)}]'
+              amu_f='out view fpdtype_t[${str(nfpts)}]'>
+    // Smoothness indicator
+    fpdtype_t totEn = 0.0, pnEn = 1e-15, s2;
+    fpdtype_t se0= ${math.log10(c['s0'])};
+
+% for i in range(nupts):
+    s2 = s[${i}]*s[${i}];
+    totEn += s2;
+
+% if ubdegs[i] >= order:
+    pnEn += s2;
+% endif
+% endfor
+
+    fpdtype_t se = log10(pnEn/totEn);
+
+    // Compute cell-wise artificial viscosity
+    fpdtype_t mu = (se < se0 - ${c['kappa']})
+                 ? 0.0
+                 : ${0.5*c['max-amu']}*(1.0 + sin(${0.5*pi/c['kappa']}*(se - se0)));
+    mu = (se < se0 + ${c['kappa']}) ? mu : ${c['max-amu']};
+
+    // Copy to all upts/fpts
+% for i in range(nupts):
+    amu_e[${i}] = mu;
+% endfor
+
+% for i in range(nfpts):
+    amu_f[${i}] = mu;
+% endfor
+</%pyfr:kernel>

--- a/pyfr/solvers/navstokes/kernels/bccflux.mako
+++ b/pyfr/solvers/navstokes/kernels/bccflux.mako
@@ -11,7 +11,8 @@
 <%pyfr:kernel name='bccflux' ndim='1'
               ul='inout view fpdtype_t[${str(nvars)}]'
               gradul='in view fpdtype_t[${str(ndims)}][${str(nvars)}]'
+              amul='in view fpdtype_t'
               nl='in fpdtype_t[${str(ndims)}]'
               magnl='in fpdtype_t'>
-    ${pyfr.expand('bc_common_flux_state', 'ul', 'gradul', 'nl', 'magnl')};
+    ${pyfr.expand('bc_common_flux_state', 'ul', 'gradul', 'amul', 'nl', 'magnl')};
 </%pyfr:kernel>

--- a/pyfr/solvers/navstokes/kernels/bcs/ghost.mako
+++ b/pyfr/solvers/navstokes/kernels/bcs/ghost.mako
@@ -5,14 +5,14 @@
 
 <% tau = c['ldg-tau'] %>
 
-<%pyfr:macro name='bc_common_flux_state' params='ul, gradul, nl, magnl'>
+<%pyfr:macro name='bc_common_flux_state' params='ul, gradul, amul, nl, magnl'>
     // Viscous states
     fpdtype_t ur[${nvars}], gradur[${ndims}][${nvars}];
     ${pyfr.expand('bc_ldg_state', 'ul', 'nl', 'ur')};
     ${pyfr.expand('bc_ldg_grad_state', 'ul', 'nl', 'gradul', 'gradur')};
 
     fpdtype_t fvr[${ndims}][${nvars}] = {{0}};
-    ${pyfr.expand('viscous_flux_add', 'ur', 'gradur', 'fvr')};
+    ${pyfr.expand('viscous_flux_add', 'ur', 'gradur', 'amul', 'fvr')};
 
     // Inviscid (Riemann solve) state
     ${pyfr.expand('bc_rsolve_state', 'ul', 'nl', 'ur')};

--- a/pyfr/solvers/navstokes/kernels/bcs/slp-adia-wall.mako
+++ b/pyfr/solvers/navstokes/kernels/bcs/slp-adia-wall.mako
@@ -15,7 +15,7 @@
     ur[${nvars - 1}] = ul[${nvars - 1}];
 </%pyfr:macro>
 
-<%pyfr:macro name='bc_common_flux_state' params='ul, gradul, nl, magnl'>
+<%pyfr:macro name='bc_common_flux_state' params='ul, gradul, amul, nl, magnl'>
     // Ghost state r
     fpdtype_t ur[${nvars}];
     ${pyfr.expand('bc_ldg_state', 'ul', 'nl', 'ur')};

--- a/pyfr/solvers/navstokes/kernels/entropy.mako
+++ b/pyfr/solvers/navstokes/kernels/entropy.mako
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+<%inherit file='base'/>
+<%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
+
+<%pyfr:kernel name='entropy' ndim='2'
+              u='in fpdtype_t[${str(nvars)}]'
+              s='out fpdtype_t'>
+    fpdtype_t invrho = 1.0/u[0], E = u[${nvars - 1}];
+
+    // Compute the pressure
+    fpdtype_t p = ${c['gamma'] - 1}*(E - 0.5*invrho*${pyfr.dot('u[{i}]', i=(1, ndims + 1))});
+
+    // Compute Entropy
+    s = p*pow(invrho, ${c['gamma']});
+</%pyfr:kernel>

--- a/pyfr/solvers/navstokes/kernels/flux.mako
+++ b/pyfr/solvers/navstokes/kernels/flux.mako
@@ -2,7 +2,7 @@
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 
 % if ndims == 2:
-<%pyfr:macro name='viscous_flux_add' params='uin, grad_uin, fout'>
+<%pyfr:macro name='viscous_flux_add' params='uin, grad_uin, amuin, fout'>
     fpdtype_t rho = uin[0], rhou = uin[1], rhov = uin[2], E = uin[3];
 
     fpdtype_t rcprho = 1.0/rho;
@@ -30,6 +30,10 @@
     fpdtype_t mu_c = ${c['mu']};
 % endif
 
+% if art_vis == 'mu':
+    mu_c += amuin;
+% endif
+
     // Compute temperature derivatives (c_v*dT/d[x,y])
     fpdtype_t T_x = rcprho*(E_x - (rcprho*rho_x*E + u*u_x + v*v_x));
     fpdtype_t T_y = rcprho*(E_y - (rcprho*rho_y*E + u*u_y + v*v_y));
@@ -46,7 +50,7 @@
     fout[1][3] += u*t_xy + v*t_yy + -mu_c*${c['gamma']/c['Pr']}*T_y;
 </%pyfr:macro>
 % elif ndims == 3:
-<%pyfr:macro name='viscous_flux_add' params='uin, grad_uin, fout'>
+<%pyfr:macro name='viscous_flux_add' params='uin, grad_uin, amuin, fout'>
     fpdtype_t rho  = uin[0];
     fpdtype_t rhou = uin[1], rhov = uin[2], rhow = uin[3];
     fpdtype_t E    = uin[4];
@@ -81,6 +85,10 @@
                    / (cpT + ${c['cpTs']});
 % else:
     fpdtype_t mu_c = ${c['mu']};
+% endif
+
+% if art_vis == 'mu':
+    mu_c += amuin;
 % endif
 
     // Compute temperature derivatives (c_v*dT/d[x,y,z])

--- a/pyfr/solvers/navstokes/kernels/intcflux.mako
+++ b/pyfr/solvers/navstokes/kernels/intcflux.mako
@@ -12,6 +12,8 @@
               ur='inout view fpdtype_t[${str(nvars)}]'
               gradul='in view fpdtype_t[${str(ndims)}][${str(nvars)}]'
               gradur='in view fpdtype_t[${str(ndims)}][${str(nvars)}]'
+              amul='in view fpdtype_t'
+              amur='in view fpdtype_t'
               nl='in fpdtype_t[${str(ndims)}]'
               magnl='in fpdtype_t'
               magnr='in fpdtype_t'>
@@ -21,12 +23,12 @@
 
 % if beta != -0.5:
     fpdtype_t fvl[${ndims}][${nvars}] = {{0}};
-    ${pyfr.expand('viscous_flux_add', 'ul', 'gradul', 'fvl')};
+    ${pyfr.expand('viscous_flux_add', 'ul', 'gradul', 'amul', 'fvl')};
 % endif
 
 % if beta != 0.5:
     fpdtype_t fvr[${ndims}][${nvars}] = {{0}};
-    ${pyfr.expand('viscous_flux_add', 'ur', 'gradur', 'fvr')};
+    ${pyfr.expand('viscous_flux_add', 'ur', 'gradur', 'amur', 'fvr')};
 % endif
 
 % for i in range(nvars):

--- a/pyfr/solvers/navstokes/kernels/mpicflux.mako
+++ b/pyfr/solvers/navstokes/kernels/mpicflux.mako
@@ -12,6 +12,8 @@
               ur='inout mpi fpdtype_t[${str(nvars)}]'
               gradul='in view fpdtype_t[${str(ndims)}][${str(nvars)}]'
               gradur='in mpi fpdtype_t[${str(ndims)}][${str(nvars)}]'
+              amul='in view fpdtype_t'
+              amur='in mpi fpdtype_t'
               nl='in fpdtype_t[${str(ndims)}]'
               magnl='in fpdtype_t'>
     // Perform the Riemann solve
@@ -20,12 +22,12 @@
 
 % if beta != -0.5:
     fpdtype_t fvl[${ndims}][${nvars}] = {{0}};
-    ${pyfr.expand('viscous_flux_add', 'ul', 'gradul', 'fvl')};
+    ${pyfr.expand('viscous_flux_add', 'ul', 'gradul', 'amul', 'fvl')};
 % endif
 
 % if beta != 0.5:
     fpdtype_t fvr[${ndims}][${nvars}] = {{0}};
-    ${pyfr.expand('viscous_flux_add', 'ur', 'gradur', 'fvr')};
+    ${pyfr.expand('viscous_flux_add', 'ur', 'gradur', 'amur', 'fvr')};
 % endif
 
 % for i in range(nvars):

--- a/pyfr/solvers/navstokes/kernels/tflux.mako
+++ b/pyfr/solvers/navstokes/kernels/tflux.mako
@@ -7,12 +7,13 @@
 <%pyfr:kernel name='tflux' ndim='2'
               u='in fpdtype_t[${str(nvars)}]'
               smats='in fpdtype_t[${str(ndims)}][${str(ndims)}]'
+              amu='in fpdtype_t'
               f='inout fpdtype_t[${str(ndims)}][${str(nvars)}]'>
     // Compute the flux (F = Fi + Fv)
     fpdtype_t ftemp[${ndims}][${nvars}];
     fpdtype_t p, v[${ndims}];
     ${pyfr.expand('inviscid_flux', 'u', 'ftemp', 'p', 'v')};
-    ${pyfr.expand('viscous_flux_add', 'u', 'f', 'ftemp')};
+    ${pyfr.expand('viscous_flux_add', 'u', 'f', 'amu', 'ftemp')};
 
     // Transform the fluxes
 % for i, j in pyfr.ndrange(ndims, nvars):

--- a/pyfr/solvers/navstokes/system.py
+++ b/pyfr/solvers/navstokes/system.py
@@ -15,3 +15,62 @@ class NavierStokesSystem(BaseAdvectionDiffusionSystem):
     mpiinterscls = NavierStokesMPIInters
     bbcinterscls = NavierStokesBaseBCInters
 
+    def rhs(self, t, uinbank, foutbank):
+        runall = self.backend.runall
+        q1, q2 = self._queues
+        kernels = self._kernels
+
+        self.eles_scal_upts_inb.active = uinbank
+        self.eles_scal_upts_outb.active = foutbank
+
+        q1 << kernels['eles', 'disu']()
+        q1 << kernels['mpiint', 'scal_fpts_pack']()
+        runall([q1])
+
+        q1 << kernels['iint', 'con_u']()
+        q1 << kernels['bcint', 'con_u']()
+        q1 << kernels['eles', 'tgradpcoru_upts']()
+        if ('eles', 'avis') in kernels:
+            q1 << kernels['eles', 'avis']()
+            q1 << kernels['mpiint', 'avis_fpts_pack']()
+
+        q2 << kernels['mpiint', 'scal_fpts_send']()
+        q2 << kernels['mpiint', 'scal_fpts_recv']()
+        q2 << kernels['mpiint', 'scal_fpts_unpack']()
+
+        runall([q1, q2])
+
+        q1 << kernels['mpiint', 'con_u']()
+        q1 << kernels['eles', 'tgradcoru_upts']()
+        q1 << kernels['eles', 'gradcoru_upts']()
+        q1 << kernels['eles', 'gradcoru_fpts']()
+        q1 << kernels['mpiint', 'vect_fpts_pack']()
+        if ('eles', 'avis') in kernels:
+            q2 << kernels['mpiint', 'avis_fpts_send']()
+            q2 << kernels['mpiint', 'avis_fpts_recv']()
+            q2 << kernels['mpiint', 'avis_fpts_unpack']()
+
+        runall([q1, q2])
+
+        if ('eles', 'gradcoru_qpts') in kernels:
+            q1 << kernels['eles', 'gradcoru_qpts']()
+        q1 << kernels['eles', 'tdisf']()
+        q1 << kernels['eles', 'tdivtpcorf']()
+        q1 << kernels['iint', 'comm_flux']()
+        q1 << kernels['bcint', 'comm_flux']()
+
+        q2 << kernels['mpiint', 'vect_fpts_send']()
+        q2 << kernels['mpiint', 'vect_fpts_recv']()
+        q2 << kernels['mpiint', 'vect_fpts_unpack']()
+
+        runall([q1, q2])
+
+        q1 << kernels['mpiint', 'comm_flux']()
+        q1 << kernels['eles', 'tdivtconf']()
+        if ('eles', 'tdivf_qpts') in kernels:
+            q1 << kernels['eles', 'tdivf_qpts']()
+            q1 << kernels['eles', 'negdivconf'](t=t)
+            q1 << kernels['eles', 'divf_upts']()
+        else:
+            q1 << kernels['eles', 'negdivconf'](t=t)
+        runall([q1])


### PR DESCRIPTION
I have added Persson's artificial viscosity scheme (AIAA 2006-0112). It requires three tuning parameters, which is defined in [solver-avis] section.

amu0 : maximum amount of artificial viscosity ~ h/p
s0 : cut-off of the smooth indicator ~ 1/p^4
kappa : range of the smooth indicator ~ empirically large

To get a proper values of them, you need to some (or many) trial-and-errors. 

This scheme is only working for Navier-Stokes system. If you want to simulate inviscid shock wave  flow, you should impose viscosity (mu in [solver] section) as 0.0.