### PR TITLE
Add a residual plugin

### DIFF
--- a/pyfr/plugins/__init__.py
+++ b/pyfr/plugins/__init__.py
@@ -3,6 +3,7 @@
 from pyfr.plugins.base import BasePlugin
 from pyfr.plugins.fluidforce import FluidForcePlugin
 from pyfr.plugins.nancheck import NaNCheckPlugin
+from pyfr.plugins.residual import ResidualPlugin
 from pyfr.plugins.sampler import SamplerPlugin
 from pyfr.util import subclass_where
 

--- a/pyfr/plugins/fluidforce.py
+++ b/pyfr/plugins/fluidforce.py
@@ -87,7 +87,7 @@ class FluidForcePlugin(BasePlugin):
 
     def __call__(self, intg):
         # Return if no output is due
-        if intg.nsteps % self.nsteps:
+        if intg.nacptsteps % self.nsteps:
             return
 
         # MPI info

--- a/pyfr/plugins/nancheck.py
+++ b/pyfr/plugins/nancheck.py
@@ -15,7 +15,7 @@ class NaNCheckPlugin(BasePlugin):
         self.nsteps = self.cfg.getint(self.cfgsect, 'nsteps')
 
     def __call__(self, intg):
-        if intg.nsteps % self.nsteps == 0:
+        if intg.nacptsteps % self.nsteps == 0:
             if any(np.isnan(np.sum(s)) for s in intg.soln):
                 raise RuntimeError('NaNs detected at t = {0}'
                                    .format(intg.tcurr))

--- a/pyfr/plugins/residual.py
+++ b/pyfr/plugins/residual.py
@@ -38,7 +38,7 @@ class ResidualPlugin(BasePlugin):
                 # Conservative variable list
                 convars = intg.system.elementscls.convarmap[self.ndims]
 
-                print(','.join(['t1', 't2'] + convars), file=self.outf)
+                print(','.join(['t'] + convars), file=self.outf)
 
     def __call__(self, intg):
         # If an output is due next step
@@ -65,8 +65,11 @@ class ResidualPlugin(BasePlugin):
                 comm.Reduce(get_mpi('in_place'), resid, op=get_mpi('sum'),
                             root=root)
 
+                # Normalise
+                resid = np.sqrt(resid) / (intg.tcurr - self._tprev)
+
                 # Build the row
-                row = [self._tprev, intg.tcurr] + np.sqrt(resid).tolist()
+                row = [intg.tcurr] + resid.tolist()
 
                 # Write
                 print(','.join(str(r) for r in row), file=self.outf)

--- a/pyfr/plugins/residual.py
+++ b/pyfr/plugins/residual.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+
+import os
+
+import numpy as np
+
+from pyfr.mpiutil import get_comm_rank_root, get_mpi
+from pyfr.plugins.base import BasePlugin
+
+
+class ResidualPlugin(BasePlugin):
+    name = 'residual'
+    systems = ['*']
+
+    def __init__(self, intg, cfgsect, suffix):
+        super().__init__(intg, cfgsect, suffix)
+
+        comm, rank, root = get_comm_rank_root()
+
+        # Output frequency
+        self.nsteps = self.cfg.getint(cfgsect, 'nsteps')
+
+        # The root rank needs to open the output file
+        if rank == root:
+            # Determine the file path
+            fname = self.cfg.get(cfgsect, 'file')
+
+            # Append the '.csv' extension
+            if not fname.endswith('.csv'):
+                fname += '.csv'
+
+            # Open for appending
+            self.outf = open(fname, 'a')
+
+            # Output a header if required
+            if (os.path.getsize(fname) == 0 and
+                self.cfg.getbool(cfgsect, 'header', True)):
+                # Conservative variable list
+                convars = intg.system.elementscls.convarmap[self.ndims]
+
+                print(','.join(['t1', 't2'] + convars), file=self.outf)
+
+    def __call__(self, intg):
+        # If an output is due next step
+        if (intg.nacptsteps + 1) % self.nsteps == 0:
+            self._prev = intg.soln
+            self._tprev = intg.tcurr
+        # If an output is due this step
+        elif intg.nacptsteps % self.nsteps == 0:
+            # MPI info
+            comm, rank, root = get_comm_rank_root()
+
+            # Previous and current solution
+            prev = self._prev
+            curr = intg.soln
+
+            # Square of the residual vector for each variable
+            resid = sum(np.linalg.norm(p - c, axis=(0, 2))**2
+                        for p, c in zip(prev, curr))
+
+            # Reduce and, if we are the root rank, output
+            if rank != root:
+                comm.Reduce(resid, None, op=get_mpi('sum'), root=root)
+            else:
+                comm.Reduce(get_mpi('in_place'), resid, op=get_mpi('sum'),
+                            root=root)
+
+                # Build the row
+                row = [self._tprev, intg.tcurr] + np.sqrt(resid).tolist()
+
+                # Write
+                print(','.join(str(r) for r in row), file=self.outf)
+
+                # Flush to disk
+                self.outf.flush()
+
+            del self._prev, self._tprev

--- a/pyfr/plugins/sampler.py
+++ b/pyfr/plugins/sampler.py
@@ -103,7 +103,7 @@ class SamplerPlugin(BasePlugin):
 
     def __call__(self, intg):
         # Return if no output is due
-        if intg.nsteps % self.nsteps:
+        if intg.nacptsteps % self.nsteps:
             return
 
         # MPI info


### PR DESCRIPTION
This adds a plugin for computing the residual.  It can be invoked by

```
[soln-plugin-residual]
nsteps = 50
file = resid.csv
header = true
```

The request also changes the existing plugins to use `nacptsteps` as opposed to `nsteps` when deciding if to run or not.  This results in more consistent output when an error estimating RK scheme is used.