### PR TITLE
Fixes export for numpy 1.10 version.

### DIFF
--- a/pyfr/writers/paraview.py
+++ b/pyfr/writers/paraview.py
@@ -120,7 +120,6 @@ class ParaviewWriter(BaseWriter):
 
                 write_s_to_fh('</PUnstructuredGrid>\n</VTKFile>\n')
 
-
     def _write_darray(self, array, vtuf, dtype):
         array = array.astype(dtype)
 
@@ -277,7 +276,7 @@ class TensorProdShapeSubDiv(BaseShapeSubDiv):
             conbase = np.hstack((conbase, conbase + (1 + n)**2))
 
         # Calculate offset of each subdivided element's nodes
-        nodeoff = np.zeros((n,)*cls.ndim)
+        nodeoff = np.zeros((n,)*cls.ndim, dtype=np.int)
         for dim, off in enumerate(np.ix_(*(range(n),)*cls.ndim)):
             nodeoff += off*(n + 1)**dim
 


### PR DESCRIPTION
Numpy 1.10.0 version changes the default casting for inplace operations to
‘same_kind’. This breaks the paraview writer. This commit fixes this.