### PR TITLE
Fix for first arg for pow in char-riemann-inv.

### DIFF
--- a/pyfr/solvers/euler/kernels/bcs/char-riem-inv.mako
+++ b/pyfr/solvers/euler/kernels/bcs/char-riem-inv.mako
@@ -6,7 +6,7 @@
 
 <%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur, ploc, t'>
     fpdtype_t cs = sqrt(${gamma}*${c['p']}/${c['rho']});
-    fpdtype_t s = ${c['p']}*pow(${c['rho']}, -${gamma});
+    fpdtype_t s = ${c['p']}*pow((fpdtype_t)${c['rho']}, -${gamma});
     fpdtype_t ratio = cs*${2.0/gmo};
 
     fpdtype_t inv = 1.0/ul[0];


### PR DESCRIPTION
This makes sure that the first argument to `pow` is always a double in the
characteristic boundary condition. In its absence, setting rho to an
integer causes cuda kernel compilation errors.