### PR TITLE
Fixes the plugin dt_out accumulated error.

### DIFF
--- a/pyfr/plugins/tavg.py
+++ b/pyfr/plugins/tavg.py
@@ -100,5 +100,5 @@ class TavgPlugin(BasePlugin):
 
                 self._writer.write(accmex, metadata, intg.tcurr)
 
-                self.tout += self.dtout
+                self.tout = intg.tcurr + self.dtout
                 self.accmex = [np.zeros_like(a) for a in accmex]

--- a/pyfr/plugins/writer.py
+++ b/pyfr/plugins/writer.py
@@ -49,4 +49,4 @@ class WriterPlugin(BasePlugin):
 
         self._writer.write(intg.soln, metadata, intg.tcurr)
 
-        self.tout_next += self.dt_out
+        self.tout_next = intg.tcurr + self.dt_out


### PR DESCRIPTION
This remedies the accumulated error in dt_out which is compared with
intg.tcurr (which does not accumulate error).