### PR TITLE
Compute the common normal vector

### DIFF
--- a/pyfr/plugins/fluidforce.py
+++ b/pyfr/plugins/fluidforce.py
@@ -106,14 +106,12 @@ class FluidForcePlugin(BasePlugin):
                     # Compute |J|^-1 SMat^T
                     rcpjact[etype] = smat*rcpdjac
 
-                area = eles.basis.faces[fidx][3]
-
                 # Unit physical normals and their magnitudes (including |J|)
                 npn = eles.get_norm_pnorms(eidx, fidx)
                 mpn = eles.get_mag_pnorms(eidx, fidx)
 
                 eidxs[etype, fidx].append(eidx)
-                norms[etype, fidx].append(mpn[:, None]*npn*area)
+                norms[etype, fidx].append(mpn[:, None]*npn)
 
             self._eidxs = {k: np.array(v) for k, v in eidxs.items()}
             self._norms = {k: np.array(v) for k, v in norms.items()}

--- a/pyfr/solvers/baseadvec/inters.py
+++ b/pyfr/solvers/baseadvec/inters.py
@@ -22,7 +22,6 @@ class BaseAdvectionIntInters(BaseInters):
 
         # Generate the constant matrices
         self._mag_pnorm_lhs = const_mat(lhs, 'get_mag_pnorms_for_inter')
-        self._mag_pnorm_rhs = const_mat(rhs, 'get_mag_pnorms_for_inter')
         self._norm_pnorm_lhs = const_mat(lhs, 'get_norm_pnorms_for_inter')
 
     def _gen_perm(self, lhs, rhs):

--- a/pyfr/solvers/euler/inters.py
+++ b/pyfr/solvers/euler/inters.py
@@ -18,8 +18,7 @@ class EulerIntInters(BaseAdvectionIntInters):
         self.kernels['comm_flux'] = lambda: self._be.kernel(
             'intcflux', tplargs=tplargs, dims=[self.ninterfpts],
             ul=self._scal0_lhs, ur=self._scal0_rhs,
-            magnl=self._mag_pnorm_lhs, magnr=self._mag_pnorm_rhs,
-            nl=self._norm_pnorm_lhs
+            magnl=self._mag_pnorm_lhs, nl=self._norm_pnorm_lhs
         )
 
 

--- a/pyfr/solvers/euler/kernels/intcflux.mako
+++ b/pyfr/solvers/euler/kernels/intcflux.mako
@@ -8,8 +8,7 @@
               ul='inout view fpdtype_t[${str(nvars)}]'
               ur='inout view fpdtype_t[${str(nvars)}]'
               nl='in fpdtype_t[${str(ndims)}]'
-              magnl='in fpdtype_t'
-              magnr='in fpdtype_t'>
+              magnl='in fpdtype_t'>
     // Perform the Riemann solve
     fpdtype_t fn[${nvars}];
     ${pyfr.expand('rsolve', 'ul', 'ur', 'nl', 'fn')};
@@ -17,6 +16,6 @@
     // Scale and write out the common normal fluxes
 % for i in range(nvars):
     ul[${i}] =  magnl*fn[${i}];
-    ur[${i}] = -magnr*fn[${i}];
+    ur[${i}] = -magnl*fn[${i}];
 % endfor
 </%pyfr:kernel>

--- a/pyfr/solvers/navstokes/inters.py
+++ b/pyfr/solvers/navstokes/inters.py
@@ -41,8 +41,7 @@ class NavierStokesIntInters(BaseAdvectionDiffusionIntInters):
             ul=self._scal0_lhs, ur=self._scal0_rhs,
             gradul=self._vect0_lhs, gradur=self._vect0_rhs,
             amul=avis0_lhs, amur=avis0_rhs,
-            magnl=self._mag_pnorm_lhs, magnr=self._mag_pnorm_rhs,
-            nl=self._norm_pnorm_lhs
+            magnl=self._mag_pnorm_lhs, nl=self._norm_pnorm_lhs
         )
 
 

--- a/pyfr/solvers/navstokes/kernels/intcflux.mako
+++ b/pyfr/solvers/navstokes/kernels/intcflux.mako
@@ -15,8 +15,7 @@
               amul='in view fpdtype_t'
               amur='in view fpdtype_t'
               nl='in fpdtype_t[${str(ndims)}]'
-              magnl='in fpdtype_t'
-              magnr='in fpdtype_t'>
+              magnl='in fpdtype_t'>
     // Perform the Riemann solve
     fpdtype_t ficomm[${nvars}], fvcomm;
     ${pyfr.expand('rsolve', 'ul', 'ur', 'nl', 'ficomm')};
@@ -51,6 +50,6 @@
 % endif
 
     ul[${i}] =  magnl*(ficomm[${i}] + fvcomm);
-    ur[${i}] = -magnr*(ficomm[${i}] + fvcomm);
+    ur[${i}] = -magnl*(ficomm[${i}] + fvcomm);
 % endfor
 </%pyfr:kernel>


### PR DESCRIPTION
This commit change the way to save normal vector.
Previous: |J|J^-T n_ref
Now: |J|J^-T n_ref dS_ref
The proposed one can be interpreted as the physical infinitesimal volume.
dV_phy = n_phy dS_phy = |J| dV_ref = |J|J^-T n_ref dS_ref.
Thus, magnl = magnr