### PR TITLE
Gradient export in the VTU writer

### DIFF
--- a/pyfr/plugins/fluidforce.py
+++ b/pyfr/plugins/fluidforce.py
@@ -135,7 +135,7 @@ class FluidForcePlugin(BasePlugin):
             ufpts = ufpts.swapaxes(0, 1)
 
             # Compute the pressure
-            p = self.elementscls.conv_to_pri(ufpts, self.cfg)[-1]
+            p = self.elementscls.con_to_pri(ufpts, self.cfg)[-1]
 
             # Get the quadrature weights and normal vectors
             qwts = self._qwts[etype, fidx]

--- a/pyfr/plugins/sampler.py
+++ b/pyfr/plugins/sampler.py
@@ -82,7 +82,7 @@ class SamplerPlugin(BasePlugin):
 
         # If necessary then convert to primitive form
         if self.fmt == 'primitive' and samps.size:
-            samps = self.elementscls.conv_to_pri(samps.T, self.cfg)
+            samps = self.elementscls.con_to_pri(samps.T, self.cfg)
             samps = np.array(samps).T
 
         return samps.tolist()

--- a/pyfr/plugins/tavg.py
+++ b/pyfr/plugins/tavg.py
@@ -53,7 +53,7 @@ class TavgPlugin(BasePlugin):
         for soln, ploc in zip(intg.soln, self.plocs):
             # Get the primitive variable names and solutions
             pnames = self.elementscls.privarmap[self.ndims]
-            psolns = self.elementscls.conv_to_pri(soln.swapaxes(0, 1),
+            psolns = self.elementscls.con_to_pri(soln.swapaxes(0, 1),
                                                   self.cfg)
 
             # Prepare the substitutions dictionary

--- a/pyfr/scripts/main.py
+++ b/pyfr/scripts/main.py
@@ -72,15 +72,11 @@ def main():
                            'from the extension of outf')
     ap_export.add_argument('-d', '--divisor', type=int, default=0,
                            help='Sets the level to which high order elements '
-                           'are divided along each edge. The total node count '
-                           'produced by divisor is equivalent to that of '
-                           'solution order, which is used as the default. '
-                           'Note: the output is linear between nodes, so '
-                           'increased resolution may be required.')
+                           'are divided; output is linear between nodes, so '
+                           'increased resolution may be required')
     ap_export.add_argument('-p', '--precision', choices=['single', 'double'],
-                           default='single', help='Selects the precision of '
-                           'floating point numbers written to the output file; '
-                           'single is the default.')
+                           default='single', help='Output number precision, '
+                           'defaults to single')
     ap_export.set_defaults(process=process_export)
 
     # Run command

--- a/pyfr/scripts/main.py
+++ b/pyfr/scripts/main.py
@@ -74,6 +74,8 @@ def main():
                            help='Sets the level to which high order elements '
                            'are divided; output is linear between nodes, so '
                            'increased resolution may be required')
+    ap_export.add_argument('-g', '--gradients', action='store_true',
+                           help='Compute gradients')
     ap_export.add_argument('-p', '--precision', choices=['single', 'double'],
                            default='single', help='Output number precision, '
                            'defaults to single')

--- a/pyfr/solvers/base/elements.py
+++ b/pyfr/solvers/base/elements.py
@@ -50,7 +50,7 @@ class BaseElements(object, metaclass=ABCMeta):
         self.nfacefpts = basis.nfacefpts
 
     @abstractmethod
-    def pri_to_conv(ics, cfg):
+    def pri_to_con(ics, cfg):
         pass
 
     def set_ics_from_cfg(self):
@@ -72,7 +72,7 @@ class BaseElements(object, metaclass=ABCMeta):
         self._scal_upts = np.empty((self.nupts, self.nvars, self.neles))
 
         # Convert from primitive to conservative form
-        for i, v in enumerate(self.pri_to_conv(ics, self.cfg)):
+        for i, v in enumerate(self.pri_to_con(ics, self.cfg)):
             self._scal_upts[:, i, :] = v
 
     def set_ics_from_soln(self, solnmat, solncfg):

--- a/pyfr/solvers/euler/elements.py
+++ b/pyfr/solvers/euler/elements.py
@@ -20,7 +20,7 @@ class BaseFluidElements(object):
     }
 
     @staticmethod
-    def pri_to_conv(pris, cfg):
+    def pri_to_con(pris, cfg):
         rho, p = pris[0], pris[-1]
 
         # Multiply velocity components by rho
@@ -33,11 +33,11 @@ class BaseFluidElements(object):
         return [rho] + rhovs + [E]
 
     @staticmethod
-    def conv_to_pri(convs, cfg):
-        rho, E = convs[0], convs[-1]
+    def con_to_pri(cons, cfg):
+        rho, E = cons[0], cons[-1]
 
         # Divide momentum components by rho
-        vs = [rhov/rho for rhov in convs[1:-1]]
+        vs = [rhov/rho for rhov in cons[1:-1]]
 
         # Compute the pressure
         gamma = cfg.getfloat('constants', 'gamma')

--- a/pyfr/writers/vtk.py
+++ b/pyfr/writers/vtk.py
@@ -57,7 +57,7 @@ class VTKWriter(BaseWriter):
 
     def _pre_proc_fields_soln(self, name, mesh, soln):
         # Convert from conservative to primitive variables
-        return np.array(self.elementscls.conv_to_pri(soln, self.cfg))
+        return np.array(self.elementscls.con_to_pri(soln, self.cfg))
 
     def _pre_proc_fields_scal(self, name, mesh, soln):
         return soln


### PR DESCRIPTION
This adds support inside of the VTU writer for exporting discontinuous gradients of the primitive variables through the `-g` flag.  A variety of performance improvements around the consistent handling of number precisions are also included.

Feedback appreciated.