### PR TITLE
Implement support for dual time stepping

### DIFF
--- a/doc/src/user_guide.rst
+++ b/doc/src/user_guide.rst
@@ -379,6 +379,10 @@ Parameterises the time-integration scheme used by the solver with
 
            *float*
 
+        - ``errest-norm`` --- norm to use for estimating the error
+
+           ``uniform`` | ``l2``
+
         - ``safety-fact`` --- safety factor for step size adjustment
           (suitable range 0.80-0.95)
 
@@ -404,6 +408,7 @@ Example::
     dt = 0.001
     atol = 0.00001
     rtol = 0.00001
+    errest-norm = l2
     safety-fact = 0.9
     min-fact = 0.3
     max-fact = 2.5

--- a/pyfr/backends/cuda/blasext.py
+++ b/pyfr/backends/cuda/blasext.py
@@ -2,36 +2,43 @@
 
 import numpy as np
 import pycuda.driver as cuda
-from pycuda.gpuarray import GPUArray, splay
+from pycuda.gpuarray import GPUArray
 from pycuda.reduction import ReductionKernel
 
-from pyfr.backends.cuda.provider import CUDAKernelProvider
+from pyfr.backends.cuda.provider import CUDAKernelProvider, get_grid_for_block
 from pyfr.backends.base import ComputeKernel
 from pyfr.nputil import npdtype_to_ctype
 
 
 class CUDABlasExtKernels(CUDAKernelProvider):
-    def axnpby(self, y, *xn):
-        if any(y.traits != x.traits for x in xn):
+    def axnpby(self, *arr, subdims=None):
+        if any(arr[0].traits != x.traits for x in arr[1:]):
             raise ValueError('Incompatible matrix types')
 
-        nv, cnt = len(xn), y.leaddim*y.nrow
+        nv = len(arr)
+        ncola, ncolb = arr[0].datashape[1:]
+        nrow, ldim, lsdim, dtype = arr[0].traits
 
         # Render the kernel template
-        src = self.backend.lookup.get_template('axnpby').render(n=nv)
+        src = self.backend.lookup.get_template('axnpby').render(
+            subdims=subdims or range(ncola), nv=nv
+        )
 
-        # Build
+        # Build the kernel
         kern = self._build_kernel('axnpby', src,
-                                  [np.int32] + [np.intp, y.dtype]*(1 + nv))
+                                  [np.int32]*4 + [np.intp]*nv + [dtype]*nv)
 
-        # Compute a suitable block and grid
-        grid, block = splay(cnt)
+        # Determine the grid/block
+        block = (128, 1, 1)
+        grid = get_grid_for_block(block, ncolb)
 
         class AxnpbyKernel(ComputeKernel):
-            def run(self, queue, beta, *alphan):
-                args = [i for axn in zip(xn, alphan) for i in axn]
+            def run(self, queue, *consts):
+                args = list(arr) + list(consts)
+
                 kern.prepared_async_call(grid, block, queue.cuda_stream_comp,
-                                         cnt, y, beta, *args)
+                                         nrow, ncolb, ldim, lsdim,
+                                         *args)
 
         return AxnpbyKernel()
 
@@ -46,7 +53,7 @@ class CUDABlasExtKernels(CUDAKernelProvider):
 
         return CopyKernel()
 
-    def errest(self, x, y, z):
+    def errest(self, x, y, z, *, norm):
         if x.traits != y.traits != z.traits:
             raise ValueError('Incompatible matrix types')
 
@@ -55,9 +62,12 @@ class CUDABlasExtKernels(CUDAKernelProvider):
         yarr = GPUArray(y.leaddim*y.nrow, y.dtype, gpudata=y)
         zarr = GPUArray(z.leaddim*z.nrow, z.dtype, gpudata=z)
 
+        # Norm type
+        reduce_expr = 'a + b' if norm == 'l2' else 'max(a, b)'
+
         # Build the reduction kernel
         rkern = ReductionKernel(
-            x.dtype, neutral='0', reduce_expr='a + b',
+            x.dtype, neutral='0', reduce_expr=reduce_expr,
             map_expr='pow(x[i]/(atol + rtol*max(fabs(y[i]), fabs(z[i]))), 2)',
             arguments='{0}* x, {0}* y, {0}* z, {0} atol, {0} rtol'
                       .format(npdtype_to_ctype(x.dtype))

--- a/pyfr/backends/mic/kernels/axnpby.mako
+++ b/pyfr/backends/mic/kernels/axnpby.mako
@@ -2,36 +2,41 @@
 <%inherit file='base'/>
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 
-static PYFR_NOINLINE void
-axnpby_inner(int n,
-             ${', '.join('fpdtype_t *__restrict__ x{0}, '
-                         'fpdtype_t a{0}'.format(i) for i in range(nv))})
-{
-    for (int i = 0; i < n; i++)
-    {
-        fpdtype_t axn = ${pyfr.dot('a{j}', 'x{j}[i]', j=(1, nv))};
-
-        if (a0 == 0.0)
-            x0[i] = axn;
-        else if (a0 == 1.0)
-            x0[i] += axn;
-        else
-            x0[i] = a0*x0[i] + axn;
-    }
-}
-
 void
-axnpby(long *n,
-       ${', '.join('fpdtype_t **x{0}'.format(i) for i in range(nv))},
-       ${', '.join('double *a{0}'.format(i) for i in range(nv))})
+axnpby(long *nrowp, long *ncolbp, long *ldimp, long *lsdimp,
+       ${', '.join('fpdtype_t **xp' + str(i) for i in range(nv))},
+       ${', '.join('double *ap' + str(i) for i in range(nv))})
 {
+    int ldim = *ldimp;
+    int lsdim = *lsdimp;
+
+% for i in range(nv):
+    fpdtype_t *x${i} = *xp${i};
+    fpdtype_t  a${i} = *ap${i};
+% endfor
+
     #pragma omp parallel
     {
-        int begin, end;
-        loop_sched_1d(*n, PYFR_ALIGN_BYTES / sizeof(fpdtype_t), &begin, &end);
+        int align = PYFR_ALIGN_BYTES / sizeof(fpdtype_t);
+        int rb, re, cb, ce;
+        loop_sched_2d(*nrowp, *ncolbp, align, &rb, &re, &cb, &ce);
 
-        axnpby_inner(end - begin,
-                     ${', '.join('*x{0} + begin, *a{0}'.format(i)
-                                 for i in range(nv))});
+        for (int r = rb; r < re; r++)
+        {
+        % for k in subdims:
+            for (int i = cb; i < ce; i++)
+            {
+                int idx = i + ldim*r + ${k}*lsdim;
+                fpdtype_t axn = ${pyfr.dot('a{l}', 'x{l}[idx]', l=(1, nv))};
+
+                if (a0 == 0.0)
+                    x0[idx] = axn;
+                else if (a0 == 1.0)
+                    x0[idx] += axn;
+                else
+                    x0[idx] = a0*x0[idx] + axn;
+            }
+        % endfor
+        }
     }
 }

--- a/pyfr/backends/mic/kernels/errest.mako
+++ b/pyfr/backends/mic/kernels/errest.mako
@@ -10,11 +10,17 @@ errest(long *n, double *out,
     fpdtype_t *x = *xp, *y = *yp, *z = *zp;
     fpdtype_t atol = *atolp, rtol = *rtolp;
 
-    fpdtype_t sum = 0.0;
+    fpdtype_t err = 0.0;
 
-    #pragma omp parallel for reduction(+:sum)
+% if norm == 'l2':
+    #pragma omp parallel for reduction(+:err)
     for (int i = 0; i < *n; i++)
-        sum += pow(x[i]/(atol + rtol*max(fabs(y[i]), fabs(z[i]))), 2);
+        err += pow(x[i]/(atol + rtol*max(fabs(y[i]), fabs(z[i]))), 2);
+% else:
+    #pragma omp parallel for reduction(max:err)
+    for (int i = 0; i < *n; i++)
+        err = max(err, pow(x[i]/(atol + rtol*max(fabs(y[i]), fabs(z[i]))), 2));
+% endif
 
-    *out = sum;
+    *out = err;
 }

--- a/pyfr/backends/opencl/blasext.py
+++ b/pyfr/backends/opencl/blasext.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import pyopencl as cl
-from pyopencl.array import Array, splay
+from pyopencl.array import Array
 from pyopencl.reduction import ReductionKernel
 
 from pyfr.backends.opencl.provider import OpenCLKernelProvider
@@ -11,30 +11,28 @@ from pyfr.nputil import npdtype_to_ctype
 
 
 class OpenCLBlasExtKernels(OpenCLKernelProvider):
-    def axnpby(self, *arr):
+    def axnpby(self, *arr, subdims=None):
         if any(arr[0].traits != x.traits for x in arr[1:]):
             raise ValueError('Incompatible matrix types')
 
         nv = len(arr)
-        nrow, leaddim, leadsubdim, dtype = arr[0].traits
+        ncola, ncolb = arr[0].datashape[1:]
+        nrow, ldim, lsdim, dtype = arr[0].traits
 
         # Render the kernel template
-        src = self.backend.lookup.get_template('axnpby').render(nv=nv)
+        src = self.backend.lookup.get_template('axnpby').render(
+            subdims=subdims or range(ncola), nv=nv
+        )
 
         # Build the kernel
         kern = self._build_kernel('axnpby', src,
-                                  [np.int32] + [np.intp]*nv + [dtype]*nv)
-
-        # Determine the total element count in the matrices
-        cnt = leaddim*nrow
-
-        # Compute a suitable global and local workgroup sizes
-        gs, ls = splay(self.backend.qdflt, cnt)
+                                  [np.int32]*4 + [np.intp]*nv + [dtype]*nv)
 
         class AxnpbyKernel(ComputeKernel):
             def run(self, queue, *consts):
                 args = [x.data for x in arr] + list(consts)
-                kern(queue.cl_queue_comp, gs, ls, cnt, *args)
+                kern(queue.cl_queue_comp, (ncolb,), None, nrow, ncolb,
+                     ldim, lsdim, *args)
 
         return AxnpbyKernel()
 
@@ -48,16 +46,19 @@ class OpenCLBlasExtKernels(OpenCLKernelProvider):
 
         return CopyKernel()
 
-    def errest(self, x, y, z):
+    def errest(self, x, y, z, *, norm):
         if x.traits != y.traits != z.traits:
             raise ValueError('Incompatible matrix types')
 
         cnt = x.leaddim*x.nrow
         dtype = x.dtype
 
+        # Norm type
+        reduce_expr = 'a + b' if norm == 'l2' else 'max(a, b)'
+
         # Build the reduction kernel
         rkern = ReductionKernel(
-            self.backend.ctx, dtype, neutral='0', reduce_expr='a + b',
+            self.backend.ctx, dtype, neutral='0', reduce_expr=reduce_expr,
             map_expr='pow(x[i]/(atol + rtol*max(fabs(y[i]), fabs(z[i]))), 2)',
             arguments='__global {0}* x, __global {0}* y, __global {0}* z, '
                       '{0} atol, {0} rtol'.format(npdtype_to_ctype(dtype))

--- a/pyfr/backends/opencl/kernels/axnpby.mako
+++ b/pyfr/backends/opencl/kernels/axnpby.mako
@@ -3,22 +3,31 @@
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 
 __kernel void
-axnpby(int n,
+axnpby(int nrow, int ncolb, int ldim, int lsdim,
        ${', '.join('__global fpdtype_t* restrict x' + str(i) for i in range(nv))},
-       ${', '.join('fpdtype_t alpha' + str(i) for i in range(nv))})
+       ${', '.join('fpdtype_t a' + str(i) for i in range(nv))})
 {
-    int strt = get_global_id(0);
-    int incr = get_global_size(0);
+    int j = get_global_id(0);
+    int idx;
 
-    for (int i = strt; i < n; i += incr)
-    {
-        fpdtype_t axn = ${pyfr.dot('alpha{j}', 'x{j}[i]', j=(1, nv))};
-
-        if (alpha0 == 0.0)
-            x0[i] = axn;
-        else if (alpha0 == 1.0)
-            x0[i] += axn;
-        else
-            x0[i] = alpha0*x0[i] + axn;
-    }
+    % for k in subdims:
+    if (j < ncolb && a0 == 0.0)
+        for (int i = 0; i < nrow; ++i)
+        {
+            idx = i*ldim + ${k}*lsdim + j;
+            x0[idx] = ${pyfr.dot('a{l}', 'x{l}[idx]', l=(1, nv))};
+        }
+    else if (j < ncolb && a0 == 1.0)
+        for (int i = 0; i < nrow; ++i)
+        {
+            idx = i*ldim + ${k}*lsdim + j;
+            x0[idx] += ${pyfr.dot('a{l}', 'x{l}[idx]', l=(1, nv))};
+        }
+    else if (j < ncolb)
+        for (int i = 0; i < nrow; ++i)
+        {
+            idx = i*ldim + ${k}*lsdim + j;
+            x0[idx] = ${pyfr.dot('a{l}', 'x{l}[idx]', l=nv)};
+        }
+    % endfor
 }

--- a/pyfr/backends/openmp/blasext.py
+++ b/pyfr/backends/openmp/blasext.py
@@ -7,23 +7,27 @@ from pyfr.backends.base import ComputeKernel
 
 
 class OpenMPBlasExtKernels(OpenMPKernelProvider):
-    def axnpby(self, y, *xn):
-        if any(y.traits != x.traits for x in xn):
+    def axnpby(self, *arr, subdims=None):
+        if any(arr[0].traits != x.traits for x in arr[1:]):
             raise ValueError('Incompatible matrix types')
 
-        nv, cnt = len(xn), y.leaddim*y.nrow
+        nv = len(arr)
+        ncola, ncolb = arr[0].datashape[1:]
+        nrow, ldim, lsdim, dtype = arr[0].traits
 
         # Render the kernel template
-        src = self.backend.lookup.get_template('axnpby').render(n=nv)
+        src = self.backend.lookup.get_template('axnpby').render(
+            subdims=subdims or range(ncola), nv=nv
+        )
 
-        # Build
+        # Build the kernel
         kern = self._build_kernel('axnpby', src,
-                                  [np.int32] + [np.intp, y.dtype]*(1 + nv))
+                                  [np.int32]*4 + [np.intp]*nv + [dtype]*nv)
 
         class AxnpbyKernel(ComputeKernel):
-            def run(self, queue, beta, *alphan):
-                args = [i for axn in zip(xn, alphan) for i in axn]
-                kern(cnt, y, beta, *args)
+            def run(self, queue, *consts):
+                args = list(arr) + list(consts)
+                kern(nrow, ncolb, ldim, lsdim, *args)
 
         return AxnpbyKernel()
 
@@ -37,7 +41,7 @@ class OpenMPBlasExtKernels(OpenMPKernelProvider):
 
         return CopyKernel()
 
-    def errest(self, x, y, z):
+    def errest(self, x, y, z, *, norm):
         if x.traits != y.traits != z.traits:
             raise ValueError('Incompatible matrix types')
 
@@ -45,7 +49,7 @@ class OpenMPBlasExtKernels(OpenMPKernelProvider):
         dtype = x.dtype
 
         # Render the reduction kernel template
-        src = self.backend.lookup.get_template('errest').render()
+        src = self.backend.lookup.get_template('errest').render(norm=norm)
 
         # Build
         rkern = self._build_kernel(

--- a/pyfr/backends/openmp/kernels/axnpby.mako
+++ b/pyfr/backends/openmp/kernels/axnpby.mako
@@ -2,36 +2,33 @@
 <%inherit file='base'/>
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 
-static PYFR_NOINLINE void
-axnpby_inner(int n, fpdtype_t *__restrict__ y, fpdtype_t beta,
-             ${', '.join('const fpdtype_t *__restrict__ x{0}, '
-                         'fpdtype_t a{0}'.format(i) for i in range(n))})
-{
-    for (int i = 0; i < n; i++)
-    {
-        fpdtype_t axn = ${pyfr.dot('a{j}', 'x{j}[i]', j=n)};
-
-        if (beta == 0.0)
-            y[i] = axn;
-        else if (beta == 1.0)
-            y[i] += axn;
-        else
-            y[i] = beta*y[i] + axn;
-    }
-}
-
 void
-axnpby(int n, fpdtype_t *__restrict__ y, fpdtype_t beta,
-       ${', '.join('const fpdtype_t *__restrict__ x{0}, '
-                   'fpdtype_t a{0}'.format(i) for i in range(n))})
+axnpby(int nrow, int ncolb, int ldim, int lsdim,
+       ${', '.join('fpdtype_t *__restrict__ x' + str(i) for i in range(nv))},
+       ${', '.join('fpdtype_t a' + str(i) for i in range(nv))})
 {
     #pragma omp parallel
     {
-        int begin, end;
-        loop_sched_1d(n, PYFR_ALIGN_BYTES / sizeof(fpdtype_t), &begin, &end);
+        int align = PYFR_ALIGN_BYTES / sizeof(fpdtype_t);
+        int rb, re, cb, ce;
+        loop_sched_2d(nrow, ncolb, align, &rb, &re, &cb, &ce);
 
-        axnpby_inner(end - begin, y + begin, beta,
-                     ${', '.join('x{0} + begin, a{0}'.format(i)
-                                 for i in range(n))});
+        for (int r = rb; r < re; r++)
+        {
+            % for k in subdims:
+            for (int i = cb; i < ce; i++)
+            {
+                int idx = i + ldim*r + ${k}*lsdim;
+                fpdtype_t axn = ${pyfr.dot('a{l}', 'x{l}[idx]', l=(1, nv))};
+
+                if (a0 == 0.0)
+                    x0[idx] = axn;
+                else if (a0 == 1.0)
+                    x0[idx] += axn;
+                else
+                    x0[idx] = a0*x0[idx] + axn;
+            }
+            % endfor
+        }
     }
 }

--- a/pyfr/backends/openmp/kernels/errest.mako
+++ b/pyfr/backends/openmp/kernels/errest.mako
@@ -6,11 +6,17 @@ fpdtype_t
 errest(int n, fpdtype_t *__restrict__ x, fpdtype_t *__restrict__ y,
        fpdtype_t *__restrict__ z, fpdtype_t atol, fpdtype_t rtol)
 {
-    fpdtype_t sum = 0.0;
+    fpdtype_t out = 0.0;
 
-    #pragma omp parallel for reduction(+:sum)
+% if norm == 'l2':
+    #pragma omp parallel for reduction(+:out)
     for (int i = 0; i < n; i++)
-        sum += pow(x[i]/(atol + rtol*max(fabs(y[i]), fabs(z[i]))), 2);
+        out += pow(x[i]/(atol + rtol*max(fabs(y[i]), fabs(z[i]))), 2);
+% else:
+    #pragma omp parallel for reduction(max:out)
+    for (int i = 0; i < n; i++)
+        out = max(out, pow(x[i]/(atol + rtol*max(fabs(y[i]), fabs(z[i]))), 2));
+% endif
 
-    return sum;
+    return out;
 }

--- a/pyfr/integrators/__init__.py
+++ b/pyfr/integrators/__init__.py
@@ -2,25 +2,42 @@
 
 import re
 
-from pyfr.integrators.controllers import BaseController
-from pyfr.integrators.steppers import BaseStepper
+from pyfr.integrators.dual import (BaseDualController, BaseDualPseudoStepper,
+                                   BaseDualStepper)
+from pyfr.integrators.std import BaseStdController, BaseStdStepper
 from pyfr.util import subclass_where
 
 
 def get_integrator(backend, systemcls, rallocs, mesh, initsoln, cfg):
-    # Look-up the controller, stepper and writer names
-    c = cfg.get('solver-time-integrator', 'controller')
-    s = cfg.get('solver-time-integrator', 'scheme')
+    form = cfg.get('solver-time-integrator', 'formulation', 'std')
 
-    controller = subclass_where(BaseController, controller_name=c)
-    stepper = subclass_where(BaseStepper, stepper_name=s)
+    if form == 'std':
+        cn = cfg.get('solver-time-integrator', 'controller')
+        sn = cfg.get('solver-time-integrator', 'scheme')
+
+        cc = subclass_where(BaseStdController, controller_name=cn)
+        sc = subclass_where(BaseStdStepper, stepper_name=sn)
+
+        bases = [(cn, cc), (sn, sc)]
+    elif form == 'dual':
+        cn = cfg.get('solver-time-integrator', 'controller')
+        pn = cfg.get('solver-time-integrator', 'pseudo-scheme')
+        sn = cfg.get('solver-time-integrator', 'scheme')
+
+        cc = subclass_where(BaseDualController, controller_name=cn)
+        pc = subclass_where(BaseDualPseudoStepper, pseudo_stepper_name=pn)
+        sc = subclass_where(BaseDualStepper, stepper_name=sn)
+
+        bases = [(cn, cc), (pn, pc), (sn, sc)]
+    else:
+        raise ValueError('Invalid integrator formulation')
 
     # Determine the integrator name
-    name = '_'.join([c, s])
+    name = '_'.join([form] + list(bn for bn, bc in bases) + ['integrator'])
     name = re.sub('(?:^|_|-)([a-z])', lambda m: m.group(1).upper(), name)
 
-    # Composite the classes together to form a new type
-    integrator = type(name, (controller, stepper), dict(name=name))
+    # Composite the base classes together to form a new type
+    integrator = type(name, tuple(bc for bn, bc in bases), dict(name=name))
 
     # Construct and return an instance of this new integrator class
     return integrator(backend, systemcls, rallocs, mesh, initsoln, cfg)

--- a/pyfr/integrators/base.py
+++ b/pyfr/integrators/base.py
@@ -2,12 +2,15 @@
 
 from abc import ABCMeta, abstractmethod, abstractproperty
 from collections import deque
+import re
+import time
 
 import numpy as np
 
 from pyfr.inifile import Inifile
 from pyfr.mpiutil import get_comm_rank_root, get_mpi
-from pyfr.util import proxylist
+from pyfr.plugins import get_plugin
+from pyfr.util import memoize, proxylist
 
 
 class BaseIntegrator(object, metaclass=ABCMeta):
@@ -17,9 +20,12 @@ class BaseIntegrator(object, metaclass=ABCMeta):
         self.cfg = cfg
         self.isrestart = initsoln is not None
 
-        # Sanity checks
-        if self._controller_needs_errest and not self._stepper_has_errest:
-            raise TypeError('Incompatible stepper/controller combination')
+        # Ensure the system is compatible with our formulation
+        if self.formulation not in systemcls.elementscls.formulations:
+            raise RuntimeError(
+                'System {0} does not support time stepping formulation {1}'
+                .format(systemcls.name, self.formulation)
+            )
 
         # Start time
         self.tstart = cfg.getfloat('solver-time-integrator', 'tstart', 0.0)
@@ -32,13 +38,26 @@ class BaseIntegrator(object, metaclass=ABCMeta):
         else:
             self.tcurr = self.tstart
 
+        # List of target times to advance to
         self.tlist = deque([self.tend])
 
-        # Determine the amount of temp storage required by thus method
+        # Accepted and rejected step counters
+        self.nacptsteps = 0
+        self.nrjctsteps = 0
+        self.nacptchain = 0
+
+        # Current and minimum time steps
+        self._dt = self.cfg.getfloat('solver-time-integrator', 'dt')
+        self.dtmin = 1.0e-12
+
+        # Determine the amount of temp storage required by this method
         nreg = self._stepper_nregs
 
         # Construct the relevant mesh partition
         self.system = systemcls(backend, rallocs, mesh, initsoln, nreg, cfg)
+
+        # Storage register banks
+        self._regs, self._regidx = self._get_reg_banks(nreg)
 
         # Extract the UUID of the mesh (to be saved with solutions)
         self.mesh_uuid = mesh['mesh_uuid']
@@ -46,28 +65,89 @@ class BaseIntegrator(object, metaclass=ABCMeta):
         # Get a queue for subclasses to use
         self._queue = backend.queue()
 
+        # Global degree of freedom count
+        self._gndofs = self._get_gndofs()
+
+        # Bank index of solution
+        self._idxcurr = 0
+
+        # Solution cache
+        self._curr_soln = None
+
+        # Add kernel cache
+        self._axnpby_kerns = {}
+
+        # Record the starting wall clock time
+        self._wstart = time.time()
+
+        # Event handlers for advance_to
+        self.completed_step_handlers = proxylist(self._get_plugins())
+
+        # Delete the memory-intensive elements map from the system
+        del self.system.ele_map
+
+    def _get_reg_banks(self, nreg):
+        regs, regidx = [], list(range(nreg))
+
+        # Create a proxylist of matrix-banks for each storage register
+        for i in regidx:
+            regs.append(
+                proxylist([self.backend.matrix_bank(em, i)
+                           for em in self.system.ele_banks])
+            )
+
+        return regs, regidx
+
+    def _get_gndofs(self):
+        comm, rank, root = get_comm_rank_root()
+
         # Get the number of degrees of freedom in this partition
         ndofs = sum(self.system.ele_ndofs)
 
-        comm, rank, root = get_comm_rank_root()
-
         # Sum to get the global number over all partitions
-        self._gndofs = comm.allreduce(ndofs, op=get_mpi('sum'))
+        return comm.allreduce(ndofs, op=get_mpi('sum'))
 
-    def _kernel(self, name, nargs):
+    def _get_plugins(self):
+        plugins = []
+
+        for s in self.cfg.sections():
+            m = re.match('soln-plugin-(.+?)(?:-(.+))?$', s)
+            if m:
+                cfgsect, name, suffix = m.group(0), m.group(1), m.group(2)
+
+                # Instantiate
+                plugins.append(get_plugin(name, self, cfgsect, suffix))
+
+        return plugins
+
+    def _get_kernels(self, name, nargs, **kwargs):
         # Transpose from [nregs][neletypes] to [neletypes][nregs]
         transregs = zip(*self._regs)
 
         # Generate an kernel for each element type
         kerns = proxylist([])
         for tr in transregs:
-            kerns.append(self.backend.kernel(name, *tr[:nargs]))
+            kerns.append(self.backend.kernel(name, *tr[:nargs], **kwargs))
 
         return kerns
 
     def _prepare_reg_banks(self, *bidxes):
         for reg, ix in zip(self._regs, bidxes):
             reg.active = ix
+
+    @memoize
+    def _get_axnpby_kerns(self, n, subdims=None):
+        return self._get_kernels('axnpby', nargs=n, subdims=subdims)
+
+    def _add(self, *args):
+        # Get a suitable set of axnpby kernels
+        axnpby = self._get_axnpby_kerns(len(args) // 2)
+
+        # Bank indices are in odd-numbered arguments
+        self._prepare_reg_banks(*args[1::2])
+
+        # Bind and run the axnpby kernels
+        self._queue % axnpby(*args[::2])
 
     def call_plugin_dt(self, dt):
         ta = self.tlist
@@ -84,20 +164,20 @@ class BaseIntegrator(object, metaclass=ABCMeta):
         tlist.extend(ta)
         tlist.extend(tb)
 
+    @property
+    def soln(self):
+        # If we do not have the solution cached then fetch it
+        if not self._curr_soln:
+            self._curr_soln = self.system.ele_scal_upts(self._idxcurr)
+
+        return self._curr_soln
+
     @abstractmethod
     def step(self, t, dt):
         pass
 
     @abstractmethod
     def advance_to(self, t):
-        pass
-
-    @abstractproperty
-    def _controller_needs_errest(self):
-        pass
-
-    @abstractproperty
-    def _stepper_has_errest(self):
         pass
 
     @abstractproperty
@@ -117,4 +197,7 @@ class BaseIntegrator(object, metaclass=ABCMeta):
             self.advance_to(t)
 
     def collect_stats(self, stats):
+        wtime = time.time() - self._wstart
+
         stats.set('solver-time-integrator', 'tcurr', self.tcurr)
+        stats.set('solver-time-integrator', 'wall-time', wtime)

--- a/pyfr/integrators/dual/__init__.py
+++ b/pyfr/integrators/dual/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+from pyfr.integrators.dual.controllers import BaseDualController
+from pyfr.integrators.dual.pseudosteppers import BaseDualPseudoStepper
+from pyfr.integrators.dual.steppers import BaseDualStepper

--- a/pyfr/integrators/dual/base.py
+++ b/pyfr/integrators/dual/base.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+from abc import abstractmethod
+
+from pyfr.integrators.base import BaseIntegrator
+
+
+class BaseDualIntegrator(BaseIntegrator):
+    formulation = 'dual'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._dtau = self.cfg.getfloat('solver-time-integrator', 'dtau')
+        self.dtaumin = 1.0e-12
+
+    @property
+    def _stepper_regidx(self):
+        return self._regidx[:self._pseudo_stepper_nregs]
+
+    @property
+    def _source_regidx(self):
+        return self._regidx[self._pseudo_stepper_nregs:]
+
+    @abstractmethod
+    def _dual_time_source(self):
+        pass
+
+    @abstractmethod
+    def finalise_step(self, currsoln):
+        pass
+
+    @abstractmethod
+    def _point_implicit_coeff(self, dt, stepper_coeff):
+        pass

--- a/pyfr/integrators/dual/controllers.py
+++ b/pyfr/integrators/dual/controllers.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+from pyfr.integrators.dual.base import BaseDualIntegrator
+
+
+class BaseDualController(BaseDualIntegrator):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Solution filtering frequency
+        self._fnsteps = self.cfg.getint('soln-filter', 'nsteps', '0')
+
+        # Stats on the most recent step
+        self.stepinfo = []
+
+    def _accept_step(self, dt, idxcurr):
+        self.tcurr += dt
+        self.nacptsteps += 1
+        self.nacptchain += 1
+
+        self._idxcurr = idxcurr
+
+        # Filter
+        if self._fnsteps and self.nacptsteps % self._fnsteps == 0:
+            self.system.filt(idxcurr)
+
+        # Invalidate the solution cache
+        self._curr_soln = None
+
+        # Fire off any event handlers
+        self.completed_step_handlers(self)
+
+    @property
+    def nsteps(self):
+        return self.nacptsteps + self.nrjctsteps
+
+
+class DualNoneController(BaseDualController):
+    controller_name = 'none'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._niters = self.cfg.getint('solver-time-integrator', 'niters')
+
+    def advance_to(self, t):
+        if t < self.tcurr:
+            raise ValueError('Advance time is in the past')
+
+        while self.tcurr < t:
+            for i in range(self._niters):
+                dt = max(min(t - self.tcurr, self._dt), self.dtmin)
+                dtau = max(min(t - self.tcurr, self._dtau), self.dtaumin)
+
+                # Take the step
+                self._idxcurr = self.step(self.tcurr, dt, dtau)
+
+            # Update the dual-time stepping banks (n+1 => n, n => n-1)
+            self.finalise_step(self._idxcurr)
+
+            # We are not adaptive, so accept every step
+            self._accept_step(dt, self._idxcurr)

--- a/pyfr/integrators/dual/pseudosteppers.py
+++ b/pyfr/integrators/dual/pseudosteppers.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+
+from pyfr.integrators.dual.base import BaseDualIntegrator
+
+
+class BaseDualPseudoStepper(BaseDualIntegrator):
+    def collect_stats(self, stats):
+        super().collect_stats(stats)
+
+        stats.set('solver-time-integrator', 'nsteps', self.nsteps)
+        stats.set('solver-time-integrator', 'nfevals', self._stepper_nfevals)
+
+    def _add_dual_source(self, dt, rhs, currsoln):
+        # Coefficients for the dual-time source term
+        coeffs = [c/dt for c in self._dual_time_source]
+
+        # Get a suitable set of axnpby kernels
+        axnpby = self._get_axnpby_kerns(len(coeffs) + 1,
+                                        subdims=self._subdims)
+
+        # Prepare the matrix banks
+        self._prepare_reg_banks(rhs, currsoln, *self._source_regidx)
+
+        # Bind and run the axnpby kernels
+        self._queue % axnpby(1.0, *coeffs)
+
+    def finalise_step(self, currsoln):
+        add = self._add
+        pnreg = self._pseudo_stepper_nregs
+
+        # Rotate the source registers to the right by one
+        self._regidx[pnreg:] = (self._source_regidx[-1:] +
+                                self._source_regidx[:-1])
+
+        # Copy the current soln into the first source register
+        add(0.0, self._regidx[pnreg], 1.0, currsoln)
+
+
+class DualPseudoEulerStepper(BaseDualPseudoStepper):
+    pseudo_stepper_name = 'euler'
+
+    @property
+    def _stepper_nfevals(self):
+        return self.nsteps
+
+    @property
+    def _pseudo_stepper_nregs(self):
+        return 2
+
+    @property
+    def _pseudo_stepper_order(self):
+        return 1
+
+    def step(self, t, dt, dtau):
+        add, add_dual_source = self._add, self._add_dual_source
+        rhs = self.system.rhs
+        ut, f = self._stepper_regidx
+
+        rhs(t, ut, f)
+        add_dual_source(dt, f, ut)
+        add(1.0, ut, dtau, f)
+
+        return ut
+
+
+class DualPseudoTVDRK3Stepper(BaseDualPseudoStepper):
+    pseudo_stepper_name = 'tvd-rk3'
+
+    @property
+    def _stepper_nfevals(self):
+        return 3*self.nsteps
+
+    @property
+    def _pseudo_stepper_nregs(self):
+        return 3
+
+    @property
+    def _pseudo_stepper_order(self):
+        return 3
+
+    def step(self, t, dt, dtau):
+        add, add_dual_source = self._add, self._add_dual_source
+        rhs = self.system.rhs
+
+        # Get the bank indices for pseudo-registers (n+1,m; n+1,m+1; rhs),
+        # where m = pseudo-time and n = real-time
+        r0, r1, r2 = self._stepper_regidx
+
+        # Ensure r0 references the bank containing u(n+1,m)
+        if r0 != self._idxcurr:
+            r0, r1 = r1, r0
+
+        # First stage;
+        # r2 = -∇·f(r0) - dQ/dt; r1 = r0 + dtau*r2
+        rhs(t, r0, r2)
+        add_dual_source(dt, r2, r0)
+        add(0.0, r1, 1.0, r0, dtau, r2)
+
+        # Second stage;
+        # r2 = -∇·f(r1) - dQ/dt; r1 = 0.75*r0 + 0.25*r1 + 0.25*dtau*r2
+        rhs(t, r1, r2)
+        add_dual_source(dt, r2, r0)
+        add(0.25, r1, 0.75, r0, dtau/4.0, r2)
+
+        # Third stage;
+        # r2 = -∇·f(r1) - dQ/dt; r1 = 1.0/3.0*r0 + 2.0/3.0*r1 + 2.0/3.0*dtau*r2
+        rhs(t, r1, r2)
+        add_dual_source(dt, r2, r1)
+        add(2.0/3.0, r1, 1.0/3.0, r0, 2.0*dtau/3.0, r2)
+
+        # Return the index of the bank containing u(n+1,m+1)
+        return r1
+
+
+class DualPseudoRK4Stepper(BaseDualPseudoStepper):
+    pseudo_stepper_name = 'rk4'
+
+    @property
+    def _stepper_nfevals(self):
+        return 4*self.nsteps
+
+    @property
+    def _pseudo_stepper_nregs(self):
+        return 3
+
+    @property
+    def _pseudo_stepper_order(self):
+        return 4
+
+    def step(self, t, dt, dtau):
+        add, add_dual_source  = self._add, self._add_dual_source
+        rhs, pi_coeff = self.system.rhs, self._point_implicit_coeff
+
+        # Get the bank indices for pseudo-registers (n+1,m; n+1,m+1; rhs),
+        # where m = pseudo-time and n = real-time
+        r0, r1, r2 = self._stepper_regidx
+
+        # Ensure r0 references the bank containing u(n+1,m)
+        if r0 != self._idxcurr:
+            r0, r1 = r1, r0
+
+        # First stage; r1 = -∇·f(r0) - dQ/dt
+        rhs(t, r0, r1)
+        add_dual_source(dt, r1, r0)
+
+        # Second stage; r2 = r0 + dtau/2*r1; r2 = -∇·f(r2) - dQ/dt
+        add(0.0, r2, 1.0, r0, dtau/2.0, r1)
+        rhs(t, r2, r2)
+        add_dual_source(dt, r2, r0)
+
+        # As no subsequent stages depend on the first stage we can
+        # reuse its register to start accumulating the solution with
+        # r1 = r0 + pi_coeff*r1 + pi_coeff*r2
+        add(pi_coeff(dt, dtau/6.0), r1, 1.0, r0, pi_coeff(dt, dtau/3.0), r2)
+
+        # Third stage; here we reuse the r2 register
+        # r2 = r0 + dtau/2*r2
+        # r2 = -∇·f(r2)
+        add(dtau/2.0, r2, 1.0, r0)
+        rhs(t, r2, r2)
+        add_dual_source(dt, r2, r0)
+
+        # Accumulate; r1 = r1 + pi_coeff*r2
+        add(1.0, r1, pi_coeff(dt, dtau/3.0), r2)
+
+        # Fourth stage; again we reuse r2
+        # r2 = r0 + dtau*r2
+        # r2 = -∇·f(r2) - dQ/dt
+        add(dtau, r2, 1.0, r0)
+        rhs(t, r2, r2)
+        add_dual_source(dt, r2, r0)
+
+        # Final accumulation r1 = r1 + pi_coeff*r2 = u(n+1,m+1)
+        add(1.0, r1, pi_coeff(dt, dtau/6.0), r2)
+
+        # Return the index of the bank containing u(n+1,m+1)
+        return r1

--- a/pyfr/integrators/dual/steppers.py
+++ b/pyfr/integrators/dual/steppers.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+from pyfr.integrators.dual.base import BaseDualIntegrator
+
+
+class BaseDualStepper(BaseDualIntegrator):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        elementscls = self.system.elementscls
+        self._subdims = [elementscls.convarmap[self.system.ndims].index(v)
+                         for v in elementscls.dualcoeffs[self.system.ndims]]
+
+    @property
+    def _stepper_nregs(self):
+        return self._pseudo_stepper_nregs + len(self._dual_time_source) - 1
+
+
+class BDF2DualStepper(BaseDualStepper):
+    stepper_name = 'bdf2'
+
+    @property
+    def _stepper_order(self):
+        return 2
+
+    @property
+    def _dual_time_source(self):
+        return [-1.5, 2.0, -0.5]
+
+    # RK4 uses point-implicit treatment to save one matrix bank
+    def _point_implicit_coeff(self, dt, stepper_coeff):
+        return stepper_coeff/(1.0 + 1.5*stepper_coeff/dt)
+
+
+class BDF3DualStepper(BaseDualStepper):
+    stepper_name = 'bdf3'
+
+    @property
+    def _stepper_order(self):
+        return 3
+
+    @property
+    def _dual_time_source(self):
+        return [-11.0/6.0, 3.0, -1.5, 1.0/3.0]
+
+    def _point_implicit_coeff(self, dt, stepper_coeff):
+        return stepper_coeff/(1.0 + 11.0*stepper_coeff/(6.0*dt))
+
+
+class BackwardEulerDualStepper(BaseDualStepper):
+    stepper_name = 'backward-euler'
+
+    @property
+    def _stepper_order(self):
+        return 1
+
+    @property
+    def _dual_time_source(self):
+        return [-1.0, 1.0]
+
+    def _point_implicit_coeff(self, dt, stepper_coeff):
+        return stepper_coeff/(1.0 + stepper_coeff/dt)

--- a/pyfr/integrators/std/__init__.py
+++ b/pyfr/integrators/std/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from pyfr.integrators.std.controllers import BaseStdController
+from pyfr.integrators.std.steppers import BaseStdStepper

--- a/pyfr/integrators/std/base.py
+++ b/pyfr/integrators/std/base.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+from abc import abstractproperty
+
+from pyfr.integrators.base import BaseIntegrator
+
+
+class BaseStdIntegrator(BaseIntegrator):
+    formulation = 'std'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Sanity checks
+        if self._controller_needs_errest and not self._stepper_has_errest:
+            raise TypeError('Incompatible stepper/controller combination')
+
+    @abstractproperty
+    def _controller_needs_errest(self):
+        pass
+
+    @abstractproperty
+    def _stepper_has_errest(self):
+        pass

--- a/pyfr/integrators/std/controllers.py
+++ b/pyfr/integrators/std/controllers.py
@@ -1,66 +1,21 @@
 # -*- coding: utf-8 -*-
 
 import math
-import re
-import time
 
-from pyfr.integrators.base import BaseIntegrator
+from pyfr.integrators.std.base import BaseStdIntegrator
 from pyfr.mpiutil import get_comm_rank_root, get_mpi
-from pyfr.plugins import get_plugin
 from pyfr.util import memoize, proxylist
 
 
-class BaseController(BaseIntegrator):
+class BaseStdController(BaseStdIntegrator):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-        # Current and minimum time steps
-        self._dt = self.cfg.getfloat('solver-time-integrator', 'dt')
-        self.dtmin = 1.0e-12
 
         # Solution filtering frequency
         self._fnsteps = self.cfg.getint('soln-filter', 'nsteps', '0')
 
-        # Bank index of solution
-        self._idxcurr = 0
-
-        # Solution cache
-        self._curr_soln = None
-
-        # Accepted and rejected step counters
-        self.nacptsteps = 0
-        self.nrjctsteps = 0
-        self.nacptchain = 0
-
         # Stats on the most recent step
         self.stepinfo = []
-
-        # Event handlers for advance_to
-        self.completed_step_handlers = proxylist([])
-
-        # Record the starting wall clock time
-        self._wstart = time.time()
-
-        # Load any plugins specified in the config file
-        for s in self.cfg.sections():
-            m = re.match('soln-plugin-(.+?)(?:-(.+))?$', s)
-            if m:
-                cfgsect, name, suffix = m.group(0), m.group(1), m.group(2)
-
-                # Instantiate
-                plugin = get_plugin(name, self, cfgsect, suffix)
-
-                # Register as an event handler
-                self.completed_step_handlers.append(plugin)
-
-        # Delete the memory-intensive elements map from the system
-        del self.system.ele_map
-
-    def collect_stats(self, stats):
-        super().collect_stats(stats)
-
-        wtime = time.time() - self._wstart
-        stats.set('solver-time-integrator', 'wall-time', wtime)
 
     def _accept_step(self, dt, idxcurr, err=None):
         self.tcurr += dt
@@ -97,16 +52,8 @@ class BaseController(BaseIntegrator):
     def nsteps(self):
         return self.nacptsteps + self.nrjctsteps
 
-    @property
-    def soln(self):
-        # If we do not have the solution cached then fetch it
-        if not self._curr_soln:
-            self._curr_soln = self.system.ele_scal_upts(self._idxcurr)
 
-        return self._curr_soln
-
-
-class NoneController(BaseController):
+class StdNoneController(BaseStdController):
     controller_name = 'none'
 
     @property
@@ -128,7 +75,7 @@ class NoneController(BaseController):
             self._accept_step(dt, idxcurr)
 
 
-class PIController(BaseController):
+class StdPIController(BaseStdController):
     controller_name = 'pi'
 
     def __init__(self, *args, **kwargs):
@@ -139,6 +86,11 @@ class PIController(BaseController):
         # Error tolerances
         self._atol = self.cfg.getfloat(sect, 'atol')
         self._rtol = self.cfg.getfloat(sect, 'rtol')
+
+        # Error norm
+        self._norm = self.cfg.get(sect, 'errest-norm', 'l2')
+        if self._norm not in {'l2', 'uniform'}:
+            raise ValueError('Invalid error norm')
 
         # PI control values
         self._alpha = self.cfg.getfloat(sect, 'pi-alpha', 0.7)
@@ -158,23 +110,33 @@ class PIController(BaseController):
 
     @memoize
     def _get_errest_kerns(self):
-        return self._kernel('errest', nargs=3)
+        return self._get_kernels('errest', nargs=3, norm=self._norm)
 
     def _errest(self, x, y, z):
         comm, rank, root = get_comm_rank_root()
 
         errest = self._get_errest_kerns()
 
-        # Obtain an estimate for the error
+        # Obtain an estimate for the squared error
         self._prepare_reg_banks(x, y, z)
         self._queue % errest(self._atol, self._rtol)
 
-        # Reduce locally (element types) and globally (MPI ranks)
-        rl = sum(errest.retval)
-        rg = comm.allreduce(rl, op=get_mpi('sum'))
+        # L2 norm
+        if self._norm == 'l2':
+            # Reduce locally (element types) and globally (MPI ranks)
+            rl = sum(errest.retval)
+            rg = comm.allreduce(rl, op=get_mpi('sum'))
 
-        # Normalise
-        err = math.sqrt(rg / self._gndofs)
+            # Normalise
+            err = math.sqrt(rg / self._gndofs)
+        # Uniform norm
+        else:
+            # Reduce locally (element types) and globally (MPI ranks)
+            rl = max(errest.retval)
+            rg = comm.allreduce(rl, op=get_mpi('max'))
+
+            # Normalise
+            err = math.sqrt(rg)
 
         return err if not math.isnan(err) else 100
 

--- a/pyfr/integrators/std/steppers.py
+++ b/pyfr/integrators/std/steppers.py
@@ -1,23 +1,11 @@
 # -*- coding: utf-8 -*-
 
-from pyfr.integrators.base import BaseIntegrator
-from pyfr.util import memoize, proxylist
+from pyfr.integrators.std.base import BaseStdIntegrator
 
 
-class BaseStepper(BaseIntegrator):
+class BaseStdStepper(BaseStdIntegrator):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-        backend = self.backend
-        elemats = self.system.ele_banks
-
-        # Create a proxylist of matrix-banks for each storage register
-        self._regs = regs = []
-        self._regidx = regidx = []
-        for i in range(self._stepper_nregs):
-            b = proxylist([backend.matrix_bank(em, i) for em in elemats])
-            regs.append(b)
-            regidx.append(i)
 
         # Add kernel cache
         self._axnpby_kerns = {}
@@ -28,22 +16,8 @@ class BaseStepper(BaseIntegrator):
         stats.set('solver-time-integrator', 'nsteps', self.nsteps)
         stats.set('solver-time-integrator', 'nfevals', self._stepper_nfevals)
 
-    @memoize
-    def _get_axnpby_kerns(self, n):
-        return self._kernel('axnpby', nargs=n)
 
-    def _add(self, *args):
-        # Get a suitable set of axnpby kernels
-        axnpby = self._get_axnpby_kerns(len(args) // 2)
-
-        # Bank indices are in odd-numbered arguments
-        self._prepare_reg_banks(*args[1::2])
-
-        # Bind and run the axnpby kernels
-        self._queue % axnpby(*args[::2])
-
-
-class EulerStepper(BaseStepper):
+class StdEulerStepper(BaseStdStepper):
     stepper_name = 'euler'
 
     @property
@@ -72,7 +46,7 @@ class EulerStepper(BaseStepper):
         return ut
 
 
-class TVDRK3Stepper(BaseStepper):
+class StdTVDRK3Stepper(BaseStdStepper):
     stepper_name = 'tvd-rk3'
 
     @property
@@ -117,7 +91,7 @@ class TVDRK3Stepper(BaseStepper):
         return r1
 
 
-class RK4Stepper(BaseStepper):
+class StdRK4StdStepper(BaseStdStepper):
     stepper_name = 'rk4'
 
     @property
@@ -180,7 +154,7 @@ class RK4Stepper(BaseStepper):
         return r1
 
 
-class RKVdH2RStepper(BaseStepper):
+class StdRKVdH2RStepper(BaseStdStepper):
     # Coefficients
     a = []
     b = []
@@ -244,7 +218,7 @@ class RKVdH2RStepper(BaseStepper):
         return (r2, rold, rerr) if errest else r2
 
 
-class RK34Stepper(RKVdH2RStepper):
+class StdRK34Stepper(StdRKVdH2RStepper):
     stepper_name = 'rk34'
 
     a = [
@@ -272,7 +246,7 @@ class RK34Stepper(RKVdH2RStepper):
         return 3
 
 
-class RK45Stepper(RKVdH2RStepper):
+class StdRK45Stepper(StdRKVdH2RStepper):
     stepper_name = 'rk45'
 
     a = [

--- a/pyfr/solvers/euler/elements.py
+++ b/pyfr/solvers/euler/elements.py
@@ -4,11 +4,15 @@ from pyfr.solvers.baseadvec import BaseAdvectionElements
 
 
 class BaseFluidElements(object):
+    formulations = ['std', 'dual']
+
     privarmap = {2: ['rho', 'u', 'v', 'p'],
                  3: ['rho', 'u', 'v', 'w', 'p']}
 
     convarmap = {2: ['rho', 'rhou', 'rhov', 'E'],
                  3: ['rho', 'rhou', 'rhov', 'rhow', 'E']}
+
+    dualcoeffs = convarmap
 
     visvarmap = {
         2: {'density': ['rho'],

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,8 @@ modules = [
     'pyfr.backends.openmp',
     'pyfr.backends.openmp.kernels',
     'pyfr.integrators',
+    'pyfr.integrators.dual',
+    'pyfr.integrators.std',
     'pyfr.plugins',
     'pyfr.quadrules',
     'pyfr.readers',


### PR DESCRIPTION
This request adds support for dual time stepping, developed by myself and Niki.  Various implicit schemes are implemented within this formulation and the existing systems have been extended to support dual time stepping formalism.

Support for the use of an uniform error norm inside of the adaptive RK schemes is also included.  This may yield better results for large scale systems however it is likely that the `atol` and `rtol` values will need to be relaxed slightly when this norm is employed.