### PR TITLE
workaround for consecutive initializations of VTKWriter instances

### DIFF
--- a/pyfr/writers/vtk.py
+++ b/pyfr/writers/vtk.py
@@ -25,8 +25,8 @@ class VTKWriter(BaseWriter):
         if self.dataprefix == 'soln':
             self._pre_proc_fields = self._pre_proc_fields_soln
             self._post_proc_fields = self._post_proc_fields_soln
-            self._soln_fields = self.elementscls.privarmap[self.ndims]
-            self._vtk_vars = self.elementscls.visvarmap[self.ndims]
+            self._soln_fields = self.elementscls.privarmap[self.ndims].copy()
+            self._vtk_vars = self.elementscls.visvarmap[self.ndims].copy()
         # Otherwise we're dealing with simple scalar data
         else:
             self._pre_proc_fields = self._pre_proc_fields_scal


### PR DESCRIPTION
_(I tried to open an issue but found no issue section in your repo. So I made changes to the source code by myself and use this pull request to let you know the problem. Hope you don't mind.)_
- **_Problem**_:

I tried to use `pyfr.writers` module to convert multiple `.pyfrs` files to VTK files in parallel. In my script, one `.pyfrs` file requires one `pyfr.writers.VTKWriter` instance. When my script handles only one `.pyfrs` file at one launch (i.e., it initializes only one `VTKWriter`instance), everything is fine. However, when it tries to handle many files at one launch (i.e., it initializes multiple `VTKWriter` instances), and **if `gradients=True`**, an error shows up complaining about out-of-bound index.

For example, consider the following code:

``` python
import argparse
import pyfr.writers

mesh = "test.pyfrm"
iFiles = ["test-0.pyfrs", "test-1.pyfrs", "test-2.pyfrs", "test-3.pyfrs"]
oFiles = ["test-0.vtu", "test-1.vtu", "test-2.vtu", "test-3.vtu"]

for i, o in zip(iFiles, oFiles):
    writerArgs = argparse.Namespace(
        meshf=mesh, solnf=i, outf=o, 
        precision="double", gradients=True, divisor=0)
    writer = pyfr.writers.get_writer_by_extn(".vtu", writerArgs)
    writer.write_out()
```

An example of the error:

```
Traceback (most recent call last):
    File "test.py", line 13, in <module>
        writer.write_out()
    File "/home/****/Downloads/PyFR-git/pyfr/writers/vtk.py", line 217, in write_out
        self._write_data(fh, mk, sk)
    File "/home/****/Downloads/PyFR-git/pyfr/writers/vtk.py", line 347, in _write_data
        for arr in self._post_proc_fields(vsoln):
    File "/home/****/Downloads/PyFR-git/pyfr/writers/vtk.py", line 119, in _post_proc_fields_grad
        fields.append(vsoln[ix])
IndexError: index 30 is out of bounds for axis 0 with size 12
```
- **_Cause**_:

I didn't try to understand the code, but I think the problem comes from two attributes of `VTKWriter`:
At [line 28](https://github.com/vincentlab/PyFR/blob/develop/pyfr/writers/vtk.py#L28) and [line 29](https://github.com/vincentlab/PyFR/blob/develop/pyfr/writers/vtk.py#L29) in [vtk.py](https://github.com/vincentlab/PyFR/blob/develop/pyfr/writers/vtk.py):

``` python
self._soln_fields = self.elementscls.privarmap[self.ndims]
self._vtk_vars = self.elementscls.visvarmap[self.ndims]
```

The attributes `_soln_fields` and `_vtk_vars` are linked to _class atributes_ `privarmap` and `visvarmap` of a target solver class. That means any in-place changes to `_soln_fields` and `_vtk_vars` may also change the `privarmap` and `visvarmap` of the target solver class. And in this case, if multiple `VTKWriter` instances are initialized consecutively, then only the first `VTKWriter` instance gets correct values for its `_soln_fields` and `_vtk_vars`, while others don't. Unfortunately, this is exactly the case when `gradients=True`, due to [line 38-56](https://github.com/vincentlab/PyFR/blob/develop/pyfr/writers/vtk.py#L38-L56).
- **_Workaround**_:

One workaround is to re-link `_soln_fields` and `_vtk_vars` to new objects when `gradients=True`, instead of using in-place modifications such as `.extend` or `+=`. For example:

``` python
if args.gradients:
    ... # other codes
    self._soln_fields = self._soln_fields + [.....]
    ... # do the same to self._vtk_vars
```

Another workaround is to copy the values when initializing `_soln_fields` and `_vtk_vars`:

``` python
self._soln_fields = self.elementscls.privarmap[self.ndims].copy()
self._vtk_vars = self.elementscls.visvarmap[self.ndims].copy()
```

I used the second workaround because it's simpler and I think it may be danger to link variables to class attributes.
