### PR TITLE
Add support for kernel caching to the C/OpenMP backend.

### DIFF
--- a/doc/src/user_guide.rst
+++ b/doc/src/user_guide.rst
@@ -21,12 +21,13 @@ Overview
 PyFR |release| has a hard dependency on Python 3.3+ and the following
 Python packages:
 
-1. `gimmik <https://github.com/vincentlab/GiMMiK>`_ >= 2.0
-2. `h5py <http://www.h5py.org/>`_ >= 2.6
-3. `mako <http://www.makotemplates.org/>`_ >= 1.0.0
-4. `mpi4py <http://mpi4py.scipy.org/>`_ >= 2.0
-5. `numpy <http://www.numpy.org/>`_ >= 1.8
-6. `pytools <https://pypi.python.org/pypi/pytools>`_ >= 2016.2.1
+1. `appdirs <https://github.com/ActiveState/appdirs>`_ >= 1.4.0
+2. `gimmik <https://github.com/vincentlab/GiMMiK>`_ >= 2.0
+3. `h5py <http://www.h5py.org/>`_ >= 2.6
+4. `mako <http://www.makotemplates.org/>`_ >= 1.0.0
+5. `mpi4py <http://mpi4py.scipy.org/>`_ >= 2.0
+6. `numpy <http://www.numpy.org/>`_ >= 1.8
+7. `pytools <https://pypi.python.org/pypi/pytools>`_ >= 2016.2.1
 
 Note that due to a bug in `numpy <http://www.numpy.org/>`_ PyFR is not
 compatible with 32-bit Python distributions.
@@ -70,6 +71,8 @@ The OpenMP backend targets multi-core CPUs. The backend requires:
 1. GCC >= 4.9
 2. A BLAS library compiled as a shared library
    (e.g. `OpenBLAS <http://www.openblas.net/>`_)
+3. Optionally `libxsmm <https://github.com/hfp/libxsmm>`_ >= 1.6
+   compiled as a shared library (STATIC=0) with BLAS=0
 
 Running in Parallel
 ^^^^^^^^^^^^^^^^^^^
@@ -218,7 +221,7 @@ Example::
     block-2d = 128, 2
 
 [backend-mic]
-^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^
 
 Parameterises the MIC backend with
 
@@ -292,6 +295,16 @@ Parameterises the OpenMP backend with
 4. ``cblas-type`` --- type of BLAS library:
 
     ``serial`` | ``parallel``
+
+5. ``gimmik-max-nnz`` --- cutoff for GiMMiK in terms of the number of
+   non-zero entires in a constant matrix:
+
+    *int*
+
+6. ``libxsmm-max-sz`` --- cutoff for libxsmm in terms of the number of
+   entires in a constant matrix:
+
+    *int*
 
 Example::
 

--- a/pyfr/backends/openmp/cblas.py
+++ b/pyfr/backends/openmp/cblas.py
@@ -50,7 +50,7 @@ class OpenMPCBLASKernels(OpenMPKernelProvider):
     def __init__(self, backend):
         super().__init__(backend)
 
-        libname = backend.cfg.getpath('backend-openmp', 'cblas', abs=False)
+        libname = backend.cfg.getpath('backend-openmp', 'cblas')
         libtype = backend.cfg.get('backend-openmp', 'cblas-type', 'parallel')
 
         if libtype not in {'serial', 'parallel'}:

--- a/pyfr/backends/openmp/kernels/par-xsmm.mako
+++ b/pyfr/backends/openmp/kernels/par-xsmm.mako
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+<%inherit file='base'/>
+
+// libxsmm prototype
+typedef void (*libxsmm_mm_t)(const fpdtype_t *,
+                             const fpdtype_t *,
+                             fpdtype_t *);
+
+void
+par_xsmm(libxsmm_mm_t xsmm, int n, int nblock,
+         const fpdtype_t *a, const fpdtype_t *b, fpdtype_t *c)
+{
+    #pragma omp parallel for
+    for (int i = 0; i < n; i += nblock)
+        xsmm(b + i, a, c + i);
+}

--- a/pyfr/backends/openmp/provider.py
+++ b/pyfr/backends/openmp/provider.py
@@ -2,7 +2,7 @@
 
 from pyfr.backends.base import (BaseKernelProvider,
                                 BasePointwiseKernelProvider, ComputeKernel)
-from pyfr.backends.openmp.compiler import GccSourceModule
+from pyfr.backends.openmp.compiler import SourceModule
 import pyfr.backends.openmp.generator as generator
 from pyfr.util import memoize
 
@@ -10,7 +10,7 @@ from pyfr.util import memoize
 class OpenMPKernelProvider(BaseKernelProvider):
     @memoize
     def _build_kernel(self, name, src, argtypes, restype=None):
-        mod = GccSourceModule(src, self.backend.cfg)
+        mod = SourceModule(src, self.backend.cfg)
         return mod.function(name, restype, argtypes)
 
 

--- a/pyfr/backends/openmp/xsmm.py
+++ b/pyfr/backends/openmp/xsmm.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+
+from ctypes import POINTER, c_int, c_double, c_float, c_void_p
+
+import numpy as np
+
+from pyfr.backends.base import ComputeKernel, NotSuitableError
+from pyfr.backends.openmp.provider import OpenMPKernelProvider
+from pyfr.ctypesutil import load_library
+
+
+class XSMMWrappers(object):
+    def __init__(self):
+        lib = load_library('xsmm')
+
+        self.libxsmm_init = lib.libxsmm_init
+        self.libxsmm_init.argtypes = []
+        self.libxsmm_init.restype = None
+
+        self.libxsmm_finalize = lib.libxsmm_finalize
+        self.libxsmm_finalize.argtypes = []
+        self.libxsmm_finalize.restype = None
+
+        self.libxsmm_dmmdispatch = lib.libxsmm_dmmdispatch
+        self.libxsmm_dmmdispatch.argtypes = [
+            c_int, c_int, c_int,
+            POINTER(c_int), POINTER(c_int), POINTER(c_int),
+            POINTER(c_double), POINTER(c_double),
+            POINTER(c_int), POINTER(c_int)
+        ]
+        self.libxsmm_dmmdispatch.restype = c_void_p
+
+        self.libxsmm_smmdispatch = lib.libxsmm_smmdispatch
+        self.libxsmm_smmdispatch.argtypes = [
+            c_int, c_int, c_int,
+            POINTER(c_int), POINTER(c_int), POINTER(c_int),
+            POINTER(c_float), POINTER(c_float),
+            POINTER(c_int), POINTER(c_int)
+        ]
+        self.libxsmm_smmdispatch.restype = c_void_p
+
+
+class OpenMPXSMMKernels(OpenMPKernelProvider):
+    def __init__(self, backend):
+        super().__init__(backend)
+
+        self.nblock = backend.soasz
+        self.max_sz = backend.cfg.getint('backend-openmp', 'libxsmm-max-sz',
+                                         125**2)
+
+        # Load and wrap libxsmm
+        self._wrappers = XSMMWrappers()
+
+        # Init
+        self._wrappers.libxsmm_init()
+
+    def __del__(self):
+        if hasattr(self, '_wrappers'):
+            self._wrappers.libxsmm_finalize()
+
+    def mul(self, a, b, out, alpha=1.0, beta=0.0):
+        w = self._wrappers
+
+        # Ensure the matrices are compatible
+        if a.nrow != out.nrow or a.ncol != b.nrow or b.ncol != out.ncol:
+            raise ValueError('Incompatible matrices for out = a*b')
+
+        # Check n is divisible by the blocking factor
+        if b.ncol % self.nblock != 0:
+            raise NotSuitableError('libxsmm requires n % nblock = 0')
+
+        # Check the matrix is of a reasonable size
+        if a.ncol*a.nrow > self.max_sz:
+            raise NotSuitableError('Matrix too large for libxsmm')
+
+        # Dimensions
+        m, n, k = a.nrow, b.ncol, a.ncol
+        lda, ldb, ldc = c_int(a.leaddim), c_int(b.leaddim), c_int(out.leaddim)
+
+        # α and β factors for C = α*(A*B) + β*C
+        if a.dtype == np.float64:
+            mmdispatch = w.libxsmm_dmmdispatch
+            alpha_ct, beta_ct = c_double(alpha), c_double(beta)
+        else:
+            mmdispatch = w.libxsmm_smmdispatch
+            alpha_ct, beta_ct = c_float(alpha), c_float(beta)
+
+        # JIT a column major multiplication kernel for a single N-block
+        xsmm_ptr = mmdispatch(self.nblock, m, k, ldb, lda, ldc,
+                              alpha_ct, beta_ct, None, c_int(0))
+
+        # Render our parallel wrapper kernel
+        src = self.backend.lookup.get_template('par-xsmm').render()
+
+        # Argument types for par_xsmm
+        argt = [np.intp, np.int32, np.int32, np.intp, np.intp, np.intp]
+
+        # Build
+        par_xsmm = self._build_kernel('par_xsmm', src, argt)
+
+        class MulKernel(ComputeKernel):
+            def run(iself, queue):
+                par_xsmm(xsmm_ptr, n, self.nblock, a, b, out)
+
+        return MulKernel()

--- a/pyfr/inifile.py
+++ b/pyfr/inifile.py
@@ -63,7 +63,8 @@ class Inifile(object):
 
         return os.path.expandvars(val)
 
-    def getpath(self, section, option, default=_sentinel, vars=None, abs=True):
+    def getpath(self, section, option, default=_sentinel, vars=None,
+                abs=False):
         path = self.get(section, option, default, vars)
         path = os.path.expanduser(path)
 

--- a/pyfr/plugins/base.py
+++ b/pyfr/plugins/base.py
@@ -51,7 +51,7 @@ class BasePlugin(object, metaclass=ABCMeta):
         self.postactmode = None
 
         if self.cfg.hasopt(cfgsect, 'post-action'):
-            self.postact = self.cfg.getpath(cfgsect, 'post-action', abs=False)
+            self.postact = self.cfg.getpath(cfgsect, 'post-action')
             self.postactmode = self.cfg.get(cfgsect, 'post-action-mode',
                                             'blocking')
 

--- a/pyfr/plugins/tavg.py
+++ b/pyfr/plugins/tavg.py
@@ -28,7 +28,7 @@ class TavgPlugin(BasePlugin):
         self.plocs = intg.system.ele_ploc_upts
 
         # Output file directory, base name, and writer
-        basedir = self.cfg.getpath(cfgsect, 'basedir', '.')
+        basedir = self.cfg.getpath(cfgsect, 'basedir', '.', abs=True)
         basename = self.cfg.get(cfgsect, 'basename')
         self._writer = NativeWriter(intg, len(self.exprs), basedir, basename,
                                     prefix='tavg')

--- a/pyfr/plugins/writer.py
+++ b/pyfr/plugins/writer.py
@@ -13,7 +13,7 @@ class WriterPlugin(BasePlugin):
         super().__init__(intg, cfgsect, suffix)
 
         # Construct the solution writer
-        basedir = self.cfg.getpath(cfgsect, 'basedir', '.')
+        basedir = self.cfg.getpath(cfgsect, 'basedir', '.', abs=True)
         basename = self.cfg.get(cfgsect, 'basename')
         self._writer = NativeWriter(intg, self.nvars, basedir, basename,
                                     prefix='soln')

--- a/pyfr/util.py
+++ b/pyfr/util.py
@@ -3,6 +3,7 @@
 from contextlib import contextmanager
 from ctypes import CDLL, c_void_p
 import functools as ft
+import hashlib
 import itertools as it
 import os
 import pickle
@@ -159,8 +160,16 @@ def ndrange(*args):
     return it.product(*map(range, args))
 
 
+def digest(*args, hash='sha256'):
+    return getattr(hashlib, hash)(pickle.dumps(args)).hexdigest()
+
+
 def rm(path):
     if os.path.isfile(path) or os.path.islink(path):
         os.remove(path)
     else:
         shutil.rmtree(path)
+
+
+def mv(src, dst):
+    shutil.move(src, dst)

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,7 @@ data_files = [
 
 # Hard dependencies
 install_requires = [
+    'appdirs >= 1.4.0',
     'gimmik >= 2.0',
     'h5py >= 2.6',
     'mako >= 1.0.0',


### PR DESCRIPTION
Kernel caching is enabled by default with the cache directory determined by the appdirs module.  The default location can be overridden by exporting

 PYFR_OMP_CACHE_DIR=/path/to/cache/dir

and disabled entirely by exporting PYFR_DEBUG_OMP_DISABLE_CACHE to any value.  The cache itself can be made read-only by making the cache directory read only.

Please note that even with the cache enabled and populated PyFR still requires access to the C compiler in order to determine the version string.

Further, this commit also adds optional support for using libxsmm as a matrix multiplication provider for the C/OpenMP backend.

These changes to a long way to improving the status of PyFR on KNL.  There is still much to do around improving start up time and run-time performance, however.