### PR TITLE
Polynomial multigrid for dual time stepping.

### DIFF
--- a/pyfr/integrators/dual/base.py
+++ b/pyfr/integrators/dual/base.py
@@ -3,24 +3,99 @@
 from abc import abstractmethod
 
 from pyfr.integrators.base import BaseIntegrator
+from pyfr.util import memoize, proxylist
 
 
 class BaseDualIntegrator(BaseIntegrator):
     formulation = 'dual'
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, backend, systemcls, rallocs, mesh, initsoln, cfg):
+        super().__init__(backend, systemcls, rallocs, mesh, initsoln, cfg)
+        sect = 'solver-time-integrator'
 
-        self._dtau = self.cfg.getfloat('solver-time-integrator', 'pseudo-dt')
+        self._dtau = self.cfg.getfloat(sect, 'pseudo-dt')
         self.dtaumin = 1.0e-12
+
+        # Dual Integrator treats following variables as lists to accommodate MG
+        self.dualsystems = []
+        self._dualregs = []
+
+        self.levels = 1
+        nreg = self._stepper_nregs
+
+        # Check whether to employ multigrid
+        self.multigrid = self.cfg.get(sect, 'controller') == 'multigrid'
+
+        if self.multigrid:
+            # Multigrid requires 3 additional registers
+            nreg += 3
+            # Number of iterations at each stage
+            self._leveliters = list(self.cfg.getliteral(sect, 'mgcycle'))
+            # Number of levels
+            self.levels = len(self._leveliters)
+
+        for level in range(self.levels):
+            self.dualsystems.append(systemcls(backend, rallocs, mesh,
+                                              initsoln, nreg, cfg, level))
+            self._dualregs.append(self._get_reg_banks(nreg, level=level)[0])
+
+        if self.multigrid:
+            self.prolongmat, self.restrictmat = self._get_prolrest_matrices()
+
+        # Indices of current and previous soln tracked between multigrid levels
+        self._dualidxcurr = [0]*self.levels
+        self._dualidxprev = [0]*self.levels
+
+        # Variables refers to the highest polynomial level for plugin support
+        self._dualregidx = self._get_reg_banks(nreg)[1]
+        self.system = self.dualsystems[0]
+        self._idxcurr = self._dualidxcurr[0]
+
+        # Event handlers for advance_to
+        self.completed_step_handlers = proxylist(self._get_plugins())
+
+        # Delete the memory-intensive elements map from the system
+        del self.system.ele_map
+
+    def _get_reg_banks(self, nreg, level=0):
+        regs, regidx = [], list(range(nreg))
+
+        # Create a proxylist of matrix-banks for each storage register
+        for i in regidx:
+            regs.append(
+                proxylist([self.backend.matrix_bank(em, i)
+                           for em in self.dualsystems[level].ele_banks])
+            )
+
+        return regs, regidx
+
+    def _prepare_reg_banks(self, *bidxes, level=0):
+        for reg, ix in zip(self._dualregs[level], bidxes):
+            reg.active = ix
+
+    def _get_kernels(self, name, nargs, level=0, **kwargs):
+        # Transpose from [nregs][neletypes] to [neletypes][nregs]
+        transregs = zip(*self._dualregs[level])
+
+        # Generate an kernel for each element type
+        kerns = proxylist([])
+        for tr in transregs:
+            kerns.append(self.backend.kernel(name, *tr[:nargs], **kwargs))
+
+        return kerns
 
     @property
     def _stepper_regidx(self):
-        return self._regidx[:self._pseudo_stepper_nregs]
+        return self._dualregidx[:self._pseudo_stepper_nregs]
 
     @property
     def _source_regidx(self):
-        return self._regidx[self._pseudo_stepper_nregs:]
+        pnreg, dsrc = self._pseudo_stepper_nregs, self._dual_time_source
+        return self._dualregidx[pnreg:pnreg + len(dsrc) - 1]
+
+    @property
+    def _mg_regidx(self):
+        return self._dualregidx[-3:]
 
     @abstractmethod
     def _dual_time_source(self):
@@ -29,3 +104,103 @@ class BaseDualIntegrator(BaseIntegrator):
     @abstractmethod
     def finalise_step(self, currsoln):
         pass
+
+    @memoize
+    def prolrest(self, l1, l2):
+        if l2 < l1:
+            opmats = self.prolongmat[l1]
+        else:
+            opmats = self.restrictmat[l1]
+
+        prolrestkerns = proxylist([])
+
+        for i in range(len(self.system.ele_types)):
+            prolrestkerns.append(
+                self.backend.kernel(
+                    'mul', opmats[i],
+                    self.dualsystems[l1].eles_scal_upts_inb[i],
+                    out=self.dualsystems[l2].eles_scal_upts_inb[i])
+            )
+
+        return prolrestkerns
+
+    def _get_prolrest_matrices(self):
+        rest = [0]*self.levels
+        prol = [0]*self.levels
+
+        for level in range(self.levels-1):
+            r = proxylist([])
+            p = proxylist([])
+            for etype in self.system.ele_types:
+                b1 = self.dualsystems[level].ele_map[etype].basis
+                b2 = self.dualsystems[level + 1].ele_map[etype].basis
+                rmat = b1.ubasis.nodal_basis_at(b2.upts)
+                pmat = b2.ubasis.nodal_basis_at(b1.upts)
+                r.append(self.backend.const_matrix(rmat, tags={'align'}))
+                p.append(self.backend.const_matrix(pmat, tags={'align'}))
+            rest[level] = r
+            prol[level + 1] = p
+
+        return prol, rest
+
+    def restrict(self, l1, l2, dt):
+        l1idxcurr, l2idxcurr = self._dualidxcurr[l1], self._dualidxcurr[l2]
+        l1sys, l2sys = self.dualsystems[l1], self.dualsystems[l2]
+        mg0, mg1, mg2 = self._mg_regidx
+
+        add, rhs = self._add, self._rhs_with_dts
+
+        # mg1 = R = -∇·f - dQ/dt
+        rhs(self.tcurr, l1idxcurr, mg1, c=1/dt, level=l1, passmg=True)
+
+        l = 0 if l1 == 0 else 1
+        # mg1 = d = r - R
+        add(-1, mg1, l, mg0, level=l1)
+
+        # Restrict Q
+        l1sys.eles_scal_upts_inb.active = l1idxcurr
+        l2sys.eles_scal_upts_inb.active = l2idxcurr
+        self._queue % self.prolrest(l1, l2)()
+
+        # Need to store Q^ns before smoothing for the up-cycle correction
+        # mg2 = Q^ns
+        add(0.0, mg2, 1, l2idxcurr, level=l2)
+
+        # Restrict d and store to m1
+        l1sys.eles_scal_upts_inb.active = mg1
+        l2sys.eles_scal_upts_inb.active = mg1
+        self._queue % self.prolrest(l1, l2)()
+
+        # mg0 = R = -∇·f - dQ/dt
+        rhs(0.0, l2idxcurr, mg0, c=1/dt, level=l2, passmg=True)
+
+        # mg0 = r = R + d
+        # r needs to be added to each RHS calculation at lower levels
+        # Handled by rhs_with_dts in pseudo-stepper class
+        add(1, mg0, 1, mg1, level=l2)
+
+        # Source terms at lower polynomial level
+        for srcidx in self._source_regidx:
+            l1sys.eles_scal_upts_inb.active = srcidx
+            l2sys.eles_scal_upts_inb.active = srcidx
+            self._queue % self.prolrest(l1, l2)()
+
+    def prolongate(self, l1, l2):
+        l1idxcurr, l2idxcurr = self._dualidxcurr[l1], self._dualidxcurr[l2]
+        l1sys, l2sys = self.dualsystems[l1], self.dualsystems[l2]
+        mg0, mg1, mg2 = self._mg_regidx
+
+        add = self._add
+
+        # Correction with respect to the non-smoothed value from down-cycle
+        # mg1 = Delta = Q^s - Q^ns
+        add(0, mg1, 1, l1idxcurr, -1, mg2, level=l1)
+
+        # Prolongate the correction and store to mg1
+        l1sys.eles_scal_upts_inb.active = mg1
+        l2sys.eles_scal_upts_inb.active = mg1
+        self._queue % self.prolrest(l1, l2)()
+
+        # Add the correction to the end quantity at l2
+        # Q^m+1  = Q^s + Delta
+        add(1, l2idxcurr, 1, mg1, level=l2)

--- a/pyfr/integrators/dual/controllers.py
+++ b/pyfr/integrators/dual/controllers.py
@@ -17,6 +17,11 @@ class BaseDualController(BaseDualIntegrator):
         # Solution filtering frequency
         self._fnsteps = self.cfg.getint('soln-filter', 'nsteps', '0')
 
+        # Pseudo-residual norm and tolerance
+        sect = 'solver-time-integrator'
+        self._pseudo_residtol= self.cfg.getfloat(sect, 'pseudo-resid-tol')
+        self._pseudo_norm = self.cfg.get(sect, 'pseudo-resid-norm', 'l2')
+
         # Stats on the most recent step
         self.pseudostepinfo = []
 
@@ -39,61 +44,6 @@ class BaseDualController(BaseDualIntegrator):
 
         # Clear the pseudo step info
         self.pseudostepinfo = []
-
-
-class DualNoneController(BaseDualController):
-    controller_name = 'none'
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        sect = 'solver-time-integrator'
-
-        self._maxniters = self.cfg.getint(sect, 'pseudo-niters-max')
-        self._minniters = self.cfg.getint(sect, 'pseudo-niters-min')
-
-        if self._maxniters < self._minniters:
-            raise ValueError('The maximum number of pseudo-iterations must '
-                             'be greater than or equal to the minimum')
-
-        self._pseudo_residtol= self.cfg.getfloat(sect, 'pseudo-resid-tol')
-        self._pseudo_norm = self.cfg.get(sect, 'pseudo-resid-norm', 'uniform')
-
-    def advance_to(self, t):
-        if t < self.tcurr:
-            raise ValueError('Advance time is in the past')
-
-        while self.tcurr < t:
-            for i in range(self._maxniters):
-                dt = max(min(t - self.tcurr, self._dt), self.dtmin)
-                dtau = max(min(t - self.tcurr, self._dtau), self.dtaumin)
-
-                # Take the step
-                self._idxcurr, self._idxprev = self.step(self.tcurr, dt, dtau)
-
-                # Activate convergence monitoring after pseudo-niters-min
-                if i >= self._minniters - 1:
-                    # Subtract the current solution from the previous solution
-                    self._add(-1.0, self._idxprev, 1.0, self._idxcurr)
-
-                    # Compute the normalised residual and check for convergence
-                    resid = self._resid(dtau, self._idxprev)
-                    self.pseudostepinfo.append((self.npseudosteps + 1, i + 1,
-                                                tuple(resid)))
-
-                    if max(resid) < self._pseudo_residtol:
-                        break
-                else:
-                    self.pseudostepinfo.append((self.npseudosteps + 1, i + 1,
-                                                (None,)*self.system.nvars))
-
-                self.npseudosteps += 1
-
-            # Update the dual-time stepping banks (n+1 => n, n => n-1)
-            self.finalise_step(self._idxcurr)
-
-            # We are not adaptive, so accept every step
-            self._accept_step(dt, self._idxcurr)
 
     @memoize
     def _get_errest_kerns(self):
@@ -125,3 +75,133 @@ class DualNoneController(BaseDualController):
 
             # Normalise and return
             return np.sqrt(res)
+
+
+class DualNoneController(BaseDualController):
+    controller_name = 'none'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        sect = 'solver-time-integrator'
+        self._maxniters = self.cfg.getint(sect, 'pseudo-niters-max')
+        self._minniters = self.cfg.getint(sect, 'pseudo-niters-min')
+
+        if self._maxniters < self._minniters:
+            raise ValueError('The maximum number of pseudo-iterations must '
+                             'be greater than or equal to the minimum')
+
+    def advance_to(self, t):
+        if t < self.tcurr:
+            raise ValueError('Advance time is in the past')
+
+        while self.tcurr < t:
+            for i in range(self._maxniters):
+                dt = max(min(t - self.tcurr, self._dt), self.dtmin)
+                dtau = max(min(t - self.tcurr, self._dtau), self.dtaumin)
+
+                # Take the step
+                idxcurr, idxprev = self.step(self.tcurr, dt, dtau)
+
+                # Activate convergence monitoring after pseudo-niters-min
+                if i >= self._minniters - 1:
+                    # Subtract the current solution from the previous solution
+                    self._add(-1.0, idxprev, 1.0, idxcurr)
+
+                    # Compute the normalised residual and check for convergence
+                    resid = self._resid(dtau, idxprev)
+                    self.pseudostepinfo.append((self.npseudosteps + 1, i + 1,
+                                                tuple(resid)))
+
+                    if max(resid) < self._pseudo_residtol:
+                        break
+                else:
+                    self.pseudostepinfo.append((self.npseudosteps + 1, i + 1,
+                                                (None,)*self.system.nvars))
+
+                self.npseudosteps += 1
+                self._dualidxcurr[0] = idxcurr
+
+            # Update the dual-time stepping banks (n+1 => n, n => n-1)
+            self.finalise_step(idxcurr)
+
+            # We are not adaptive, so accept every step
+            self._accept_step(dt, idxcurr)
+
+
+class DualMgController(BaseDualController):
+    controller_name = 'multigrid'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        sect = 'solver-time-integrator'
+        self._maxcycles = self.cfg.getint(sect, 'pseudo-mgcycles-max')
+        self._mincycles = self.cfg.getint(sect, 'pseudo-mgcycles-min')
+
+        if self._maxcycles < self._mincycles:
+            raise ValueError('The maximum number of multigrid cycles must '
+                             'be greater than or equal to the minimum')
+
+        # Pseudo time step factor for multigrid; dtau(level) = a^level*dtaumin
+        dtaufact = self.cfg.getfloat(sect, 'pseudo-dt-fact', 1.25)
+        self._dtaus = [dtaufact**i * self._dtau for i in range(self.levels)]
+
+    def advance_to(self, t):
+        if t < self.tcurr:
+            raise ValueError('Advance time is in the past')
+
+        lvliters = self._leveliters
+        idxcurr = self._dualidxcurr
+        idxprev = self._dualidxprev
+        dtaus = self._dtaus
+        lvls = self.levels - 1
+
+        while self.tcurr < t:
+            dt = max(min(t - self.tcurr, self._dt), self.dtmin)
+
+            # Number of V-cycles
+            for i in range(self._maxcycles):
+                # V-cycle down
+                for j in range(lvls):
+                    for k in range(lvliters[j]):
+                        dtau = max(min(t - self.tcurr, dtaus[j]), self.dtaumin)
+                        idxcurr[j], idxprev[j] = self.step(self.tcurr, dt,
+                                                           dtau, level=j)
+                    self.restrict(j, j + 1, dt)
+
+                # V-cycle up
+                for j in range(lvls, 0, -1):
+                    for k in range(lvliters[j]):
+                        dtau = max(min(t - self.tcurr, dtaus[j]), self.dtaumin)
+                        idxcurr[j], idxprev[j] = self.step(self.tcurr, dt,
+                                                           dtau, level=j)
+                    self.prolongate(j, j - 1)
+
+                # Post-smoothing at the highest level
+                for k in range(lvliters[0]):
+                    dtau = max(min(t - self.tcurr, dtaus[0]), self.dtaumin)
+                    idxcurr[0], idxprev[0] = self.step(self.tcurr, dt,
+                                                       dtau, level=0)
+
+                if i >= self._mincycles - 1:
+                    # Subtract the current solution from the previous solution
+                    self._add(-1.0, idxprev[0], 1.0, idxcurr[0], level=0)
+
+                    # Compute the normalised residual and check for convergence
+                    resid = self._resid(dtaus[0], idxprev[0])
+                    self.pseudostepinfo.append((self.npseudosteps + 1, i + 1,
+                                                tuple(resid)))
+
+                    if max(resid) < self._pseudo_residtol:
+                        break
+                else:
+                    self.pseudostepinfo.append((self.npseudosteps + 1, i + 1,
+                                                (None,)*self.system.nvars))
+                self.npseudosteps += 1
+
+            # Update the dual-time stepping banks (n+1 => n, n => n-1)
+            self.finalise_step(idxcurr[0])
+
+            # We are not adaptive, so accept every step
+            self._accept_step(dt, idxcurr[0])

--- a/pyfr/integrators/dual/pseudosteppers.py
+++ b/pyfr/integrators/dual/pseudosteppers.py
@@ -13,32 +13,37 @@ class BaseDualPseudoStepper(BaseDualIntegrator):
         # Total number of pseudo-steps
         stats.set('solver-time-integrator', 'npseudosteps', self.npseudosteps)
 
-    def _add_with_dts(self, *args, c):
-        vals, regs = list(args[::2]), list(args[1::2])
+    def _rhs_with_dts(self, t, *args, c, level=0, passmg=False):
+        idxcurr = self._dualidxcurr
+        mgregidx, srcidx = self._mg_regidx, self._source_regidx
+        kerns, banks = self._get_axnpby_kerns, self._prepare_reg_banks
+
+        # Compute -∇·f
+        self.dualsystems[level].rhs(t, *args)
 
         # Coefficients for the dual-time source term
         svals = [c*sc for sc in self._dual_time_source]
 
-        # Normal addition
-        axnpby = self._get_axnpby_kerns(len(vals))
-        self._prepare_reg_banks(*regs)
-        self._queue % axnpby(*vals)
-
-        # Source addition
-        axnpby = self._get_axnpby_kerns(len(svals) + 1, subdims=self._subdims)
-        self._prepare_reg_banks(regs[0], self._idxcurr, *self._source_regidx)
+        # Source addition -∇·f - dQ/dt
+        axnpby = kerns(len(svals) + 1, subdims=self._subdims, level=level)
+        banks(args[1], idxcurr[level], *srcidx, level=level)
         self._queue % axnpby(1, *svals)
 
-    def finalise_step(self, currsoln):
-        add = self._add
-        pnreg = self._pseudo_stepper_nregs
+        if self.multigrid and level != 0 and passmg is not True:
+            # Include residual defects at lower polynomial multigrid levels
+            axnpby = kerns(2, subdims=self._subdims, level=level)
+            banks(args[1], mgregidx[0], level=level)
+            self._queue % axnpby(1, -1)
+
+    def finalise_step(self, currsoln, level=0):
+        pnreg, regidx = self._pseudo_stepper_nregs, self._dualregidx
+        dsrc, srcidx = self._dual_time_source, self._source_regidx
 
         # Rotate the source registers to the right by one
-        self._regidx[pnreg:] = (self._source_regidx[-1:] +
-                                self._source_regidx[:-1])
+        regidx[pnreg:pnreg + len(dsrc) - 1] = (srcidx[-1:] + srcidx[:-1])
 
         # Copy the current soln into the first source register
-        add(0.0, self._regidx[pnreg], 1.0, currsoln)
+        self._add(0, regidx[pnreg], 1, currsoln, level=level)
 
 
 class DualPseudoEulerStepper(BaseDualPseudoStepper):
@@ -56,17 +61,16 @@ class DualPseudoEulerStepper(BaseDualPseudoStepper):
     def _pseudo_stepper_order(self):
         return 1
 
-    def step(self, t, dt, dtau):
-        add, add_with_dts = self._add, self._add_with_dts
-        rhs = self.system.rhs
+    def step(self, t, dt, dtau, level=0):
+        add = self._add
+        rhs = self._rhs_with_dts
         r0, r1 = self._stepper_regidx
-        rat = dtau / dt
 
-        if r0 != self._idxcurr:
+        if r0 != self._dualidxcurr[level]:
             r0, r1 = r1, r0
 
-        rhs(t, r0, r1)
-        add_with_dts(0, r1, 1, r0, dtau, r1, c=rat)
+        rhs(t, r0, r1, c=1/dt, level=level)
+        add(0, r1, 1, r0, dtau, r1, level=level)
 
         return r1, r0
 
@@ -86,33 +90,32 @@ class DualPseudoTVDRK3Stepper(BaseDualPseudoStepper):
     def _pseudo_stepper_order(self):
         return 3
 
-    def step(self, t, dt, dtau):
-        add, add_with_dts = self._add, self._add_with_dts
-        rhs = self.system.rhs
-        rat = dtau / dt
+    def step(self, t, dt, dtau, level=0):
+        add = self._add
+        rhs = self._rhs_with_dts
 
         # Get the bank indices for pseudo-registers (n+1,m; n+1,m+1; rhs),
         # where m = pseudo-time and n = real-time
         r0, r1, r2 = self._stepper_regidx
 
         # Ensure r0 references the bank containing u(n+1,m)
-        if r0 != self._idxcurr:
+        if r0 != self._dualidxcurr[level]:
             r0, r1 = r1, r0
 
         # First stage;
-        # r2 = -∇·f(r0); r1 = r0 + dtau*r2 - dtau*dQ/dt;
-        rhs(t, r0, r2)
-        add_with_dts(0, r1, 1, r0, dtau, r2, c=rat)
+        # r2 = -∇·f(r0) - dQ/dt; r1 = r0 + dtau*r2;
+        rhs(t, r0, r2, c=1/dt, level=level)
+        add(0, r1, 1, r0, dtau, r2, level=level)
 
         # Second stage;
-        # r2 = -∇·f(r1); r1 = 3/4*r0 + 1/4*r1 + 1/4*dtau*r2 - dtau/4*dQ/dt
-        rhs(t, r1, r2)
-        add_with_dts(1/4, r1, 3/4, r0, dtau/4, r2, c=rat/4)
+        # r2 = -∇·f(r1) - dQ/dt; r1 = 3/4*r0 + 1/4*r1 + 1/4*dtau*r2
+        rhs(t, r1, r2, c=1/dt, level=level)
+        add(1/4, r1, 3/4, r0, dtau/4, r2, level=level)
 
         # Third stage;
-        # r2 = -∇·f(r1); r1 = 1/3*r0 + 2/3*r1 + 2/3*dtau*r2 - 2/3*dtau*dQ/dt
-        rhs(t, r1, r2)
-        add_with_dts(2/3, r1, 1/3, r0, 2*dtau/3, r2, c=2*rat/3)
+        # r2 = -∇·f(r1) - dQ/dt; r1 = 1/3*r0 + 2/3*r1 + 2/3*dtau*r2 -
+        rhs(t, r1, r2, c=1/dt, level=level)
+        add(2/3, r1, 1/3, r0, 2*dtau/3, r2, level=level)
 
         # Return the index of the bank containing u(n+1,m+1)
         return r1, r0
@@ -133,48 +136,47 @@ class DualPseudoRK4Stepper(BaseDualPseudoStepper):
     def _pseudo_stepper_order(self):
         return 4
 
-    def step(self, t, dt, dtau):
-        add, add_with_dts  = self._add, self._add_with_dts
-        rhs = self.system.rhs
-        rat = dtau / dt
+    def step(self, t, dt, dtau, level=0):
+        add = self._add
+        rhs = self._rhs_with_dts
 
         # Get the bank indices for pseudo-registers (n+1,m; n+1,m+1; rhs),
         # where m = pseudo-time and n = real-time
         r0, r1, r2 = self._stepper_regidx
 
         # Ensure r0 references the bank containing u(n+1,m)
-        if r0 != self._idxcurr:
+        if r0 != self._dualidxcurr[level]:
             r0, r1 = r1, r0
 
-        # First stage; r1 = -∇·f(r0)
-        rhs(t, r0, r1)
+        # First stage; r1 = -∇·f(r0) - dQ/dt;
+        rhs(t, r0, r1, c=1/dt, level=level)
 
-        # Second stage; r2 = r0 + dtau/2*r1 - dtau/2*dQ/dt; r2 = -∇·f(r2)
-        add_with_dts(0, r2, 1, r0, dtau/2, r1, c=rat/2)
-        rhs(t, r2, r2)
+        # Second stage; r2 = r0 + dtau/2*r1; r2 = -∇·f(r2) - dQ/dt;
+        add(0, r2, 1, r0, dtau/2, r1, level=level)
+        rhs(t, r2, r2, c=1/dt, level=level)
 
         # As no subsequent stages depend on the first stage we can
         # reuse its register to start accumulating the solution with
-        # r1 = r0 + dtau/6*r1 + dtau/3*r2 -(dtau/6+dtau/3)*dQ/dt
-        add_with_dts(dtau/6, r1, 1, r0, dtau/3, r2, c=(1/6+1/3)*rat)
+        # r1 = r0 + dtau/6*r1 + dtau/3*r2
+        add(dtau/6, r1, 1, r0, dtau/3, r2, level=level)
 
         # Third stage; here we reuse the r2 register
         # r2 = r0 + dtau/2*r2 - dtau/2*dQ/dt
-        # r2 = -∇·f(r2)
-        add_with_dts(dtau/2, r2, 1, r0, c=rat/2)
-        rhs(t, r2, r2)
+        # r2 = -∇·f(r2) - dQ/dt;
+        add(dtau/2, r2, 1, r0, level=level)
+        rhs(t, r2, r2, c=1/dt, level=level)
 
-        # Accumulate; r1 = r1 + dtau/3*r2 - dtau/3*dQ/dt
-        add_with_dts(1, r1, dtau/3, r2, c=rat/3)
+        # Accumulate; r1 = r1 + dtau/3*r2
+        add(1, r1, dtau/3, r2, level=level)
 
         # Fourth stage; again we reuse r2
-        # r2 = r0 + dtau*r2 - dtau*dQ/dt
-        # r2 = -∇·f(r2)
-        add_with_dts(dtau, r2, 1, r0, c=rat)
-        rhs(t, r2, r2)
+        # r2 = r0 + dtau*r2
+        # r2 = -∇·f(r2) - dQ/dt;
+        add(dtau, r2, 1, r0, level=level)
+        rhs(t, r2, r2, c=1/dt, level=level)
 
-        # Final accumulation r1 = r1 + dtau/6*r2 - dtau/6*dQ/dt = u(n+1,m+1)
-        add_with_dts(1, r1, dtau/6, r2, c=rat/6)
+        # Final accumulation r1 = r1 + dtau/6*r2 = u(n+1,m+1)
+        add(1, r1, dtau/6, r2, level=level)
 
         # Return the index of the bank containing u(n+1,m+1)
         return r1, r0

--- a/pyfr/integrators/std/base.py
+++ b/pyfr/integrators/std/base.py
@@ -3,7 +3,7 @@
 from abc import abstractproperty
 
 from pyfr.integrators.base import BaseIntegrator
-
+from pyfr.util import proxylist
 
 class BaseStdIntegrator(BaseIntegrator):
     formulation = 'std'
@@ -11,9 +11,23 @@ class BaseStdIntegrator(BaseIntegrator):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        nreg = self._stepper_nregs
+
+        # Storage register banks
+        self._regs, self._regidx = self._get_reg_banks(nreg)
+
+        # Bank index of solution
+        self._idxcurr = 0
+
         # Sanity checks
         if self._controller_needs_errest and not self._stepper_has_errest:
             raise TypeError('Incompatible stepper/controller combination')
+
+        # Event handlers for advance_to
+        self.completed_step_handlers = proxylist(self._get_plugins())
+
+        # Delete the memory-intensive elements map from the system
+        del self.system.ele_map
 
     @abstractproperty
     def _controller_needs_errest(self):

--- a/pyfr/shapes.py
+++ b/pyfr/shapes.py
@@ -35,10 +35,10 @@ class BaseShape(object):
         'quad': lambda order: (order + 1)**2
     }
 
-    def __init__(self, nspts, cfg):
+    def __init__(self, nspts, cfg, level=0):
         self.nspts = nspts
         self.cfg = cfg
-        self.order = cfg.getint('solver', 'order')
+        self.order = cfg.getint('solver', 'order') - level
 
         self.antialias = cfg.get('solver', 'anti-alias', 'none')
         self.antialias = {s.strip() for s in self.antialias.split(',')}

--- a/pyfr/solvers/base/elements.py
+++ b/pyfr/solvers/base/elements.py
@@ -14,11 +14,12 @@ class BaseElements(object, metaclass=ABCMeta):
     privarmap = None
     convarmap = None
 
-    def __init__(self, basiscls, eles, cfg):
+    def __init__(self, basiscls, eles, cfg, level=0):
         self._be = None
 
         self.eles = eles
         self.cfg = cfg
+        self.level = level
 
         self.nspts = nspts = eles.shape[0]
         self.neles = neles = eles.shape[1]
@@ -35,7 +36,7 @@ class BaseElements(object, metaclass=ABCMeta):
         self.nvars = len(self.privarmap[ndims])
 
         # Instantiate the basis class
-        self.basis = basis = basiscls(nspts, cfg)
+        self.basis = basis = basiscls(nspts, cfg, level)
 
         # See what kind of projection the basis is using
         self.antialias = basis.antialias
@@ -144,8 +145,8 @@ class BaseElements(object, metaclass=ABCMeta):
 
         # Convenience functions for scalar/vector allocation
         alloc = lambda ex, n: abufs.append(
-            backend.matrix(n, extent=nonce + ex, tags={'align'})
-        ) or abufs[-1]
+            backend.matrix(n, extent='{0}_{1}'.format(nonce, self.level),
+                           tags={'align'})) or abufs[-1]
         salloc = lambda ex, n: alloc(ex, (n, nvars, neles))
         valloc = lambda ex, n: alloc(ex, (ndims, n, nvars, neles))
 

--- a/pyfr/solvers/base/system.py
+++ b/pyfr/solvers/base/system.py
@@ -22,7 +22,7 @@ class BaseSystem(object, metaclass=ABCMeta):
     # Nonce sequence
     _nonce_seq = it.count()
 
-    def __init__(self, backend, rallocs, mesh, initsoln, nreg, cfg):
+    def __init__(self, backend, rallocs, mesh, initsoln, nreg, cfg, level=0):
         self.backend = backend
         self.mesh = mesh
         self.cfg = cfg
@@ -31,7 +31,8 @@ class BaseSystem(object, metaclass=ABCMeta):
         nonce = str(next(self._nonce_seq))
 
         # Load the elements
-        eles, elemap = self._load_eles(rallocs, mesh, initsoln, nreg, nonce)
+        eles, elemap = self._load_eles(rallocs, mesh, initsoln,
+                                       nreg, nonce, level)
         backend.commit()
 
         # Retain the element map; this may be deleted by clients
@@ -65,7 +66,7 @@ class BaseSystem(object, metaclass=ABCMeta):
         self._gen_kernels(eles, int_inters, mpi_inters, bc_inters)
         backend.commit()
 
-    def _load_eles(self, rallocs, mesh, initsoln, nreg, nonce):
+    def _load_eles(self, rallocs, mesh, initsoln, nreg, nonce, level):
         basismap = {b.name: b for b in subclasses(BaseShape, just_leaf=True)}
 
         # Look for and load each element type from the mesh
@@ -76,7 +77,8 @@ class BaseSystem(object, metaclass=ABCMeta):
                 # Element type
                 t = m.group(1)
 
-                elemap[t] = self.elementscls(basismap[t], mesh[f], self.cfg)
+                elemap[t] = self.elementscls(basismap[t], mesh[f],
+                                             self.cfg, level=level)
 
         # Construct a proxylist to simplify collective operations
         eles = proxylist(elemap.values())


### PR DESCRIPTION
I changed the structure so that only the DualIntegrator is affected. Now, DualIntegrator uses variable length lists for systems and registers. Even without multigrid they are lists with length one, just to make the necessary methods suitable for both cases without too many if statements.

Another bigger change is in the pseudostepper implementation. Previously we added the real time derivative source term at each stage addition using the method _add_with_dts. Now, the real-time derivative is added directly to the register containing -div(f) with _rhs_with_dts.  This makes pseudosteppers cleaner and also facilitates local time stepping, so that it can be handled with a single pointwise multiplication.

Thanks!
