### PR TITLE
Improvements for Windows Platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 MANIFEST
 dist/
 build/
+pyfr.egg-info/
 
 # Documentation
 doc/build/

--- a/doc/src/user_guide.rst
+++ b/doc/src/user_guide.rst
@@ -151,7 +151,7 @@ Running in Parallel
 ^^^^^^^^^^^^^^^^^^^
 
 ``pyfr`` can be run in parallel. To do so prefix ``pyfr`` with
-``mpirun -n <cores/devices>``. Note that the mesh must be
+``mpiexec -n <cores/devices>``. Note that the mesh must be
 pre-partitioned, and the number of cores or devices must be equal to
 the number of partitions.
 
@@ -1456,7 +1456,7 @@ simulation on a structured mesh:
 6. Run pyfr to solve the Euler equations on the mesh, generating a
    series of PyFR solution files called ``euler_vortex_2d*.pyfrs``::
 
-        mpirun -n 2 pyfr run -b cuda -p euler_vortex_2d.pyfrm euler_vortex_2d.ini
+        mpiexec -n 2 pyfr run -b cuda -p euler_vortex_2d.pyfrm euler_vortex_2d.ini
 
 7. Run pyfr on the solution file ``euler_vortex_2d-100.0.pyfrs``
    converting it into an unstructured VTK file called

--- a/pyfr/ctypesutil.py
+++ b/pyfr/ctypesutil.py
@@ -8,7 +8,10 @@ import sys
 
 def get_libc_function(fn):
     if sys.platform == 'win32':
-        libc = ctypes.windll.msvcrt
+        if sys.version_info.minor >= 5:
+            libc = ctypes.windll.msvcrt
+        else:
+            libc = ctypes.CDLL(ctypes.util.find_msvcrt())
     else:
         libc = ctypes.CDLL(ctypes.util.find_library('c'))
 


### PR DESCRIPTION
- Further modified the way the C runtime library is loaded to be friendly to Python 3.3 and 3.4 users on Windows
- Updated progress bar display
- Instruct to use mpiexec for parallel runs, as mpirun is not available from some distributions (i.e. MS-MPI)
- using the recommended "Development Mode" from distutils works well, but creates an egg-info folder in the root dir. gitignore'd it.