### PR TITLE
add commen tfor solution of mul error  when runing 6 order euler example

### DIFF
--- a/examples/euler_vortex_2d/euler_vortex_2d.ini
+++ b/examples/euler_vortex_2d/euler_vortex_2d.ini
@@ -3,6 +3,7 @@ precision = double
 rank-allocator = linear
 
 [backend-openmp]
+;if you suffer from some error like "KeyError: "'mul' has no providers""  while changing order up to 6 and using backend openmp, maybe you can add path of "cblas" to pass away the error
 ;cblas = Enter path to local BLAS library for OpenMP backend
 
 [constants]


### PR DESCRIPTION
Hi, vincentlab.


Recently, I ran the example of "2d euler flow" as a test case of PyFR.


If its solver order more than 6, there's a error like 

> KeyError: "'mul' has no providers"

always along with the openmp backend.

I did somethings like RTFM and found the links in mailing list(https://groups.google.com/forum/#!topic/pyfrmailinglist/Fj0PMm8n8Pc), then add the cblas path in backend-openmp getting rid of the "mul"

Maybe the example need some comments to help newbie when editing the default config file.:-)

Regards,
LIN Ruoshui
