### PR TITLE
Updated no-slip isothermal BCs

### DIFF
--- a/pyfr/solvers/navstokes/inters.py
+++ b/pyfr/solvers/navstokes/inters.py
@@ -105,11 +105,14 @@ class NavierStokesNoSlpIsotWallBCInters(NavierStokesBaseBCInters):
     type = 'no-slp-isot-wall'
     cflux_state = 'ghost'
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, be, lhs, elemap, cfgsect, cfg):
+        super().__init__(be, lhs, elemap, cfgsect, cfg)
 
         self._tpl_c['cpTw'], = self._eval_opts(['cpTw'])
-        self._tpl_c['v'] = self._eval_opts('uvw'[:self.ndims], default='0')
+        self._tpl_c.update(
+            self._exp_opts('uvw'[:self.ndims], lhs,
+                           default={'u': 0, 'v': 0, 'w': 0})
+        )
 
 
 class NavierStokesNoSlpAdiaWallBCInters(NavierStokesBaseBCInters):

--- a/pyfr/solvers/navstokes/kernels/bcs/no-slp-isot-wall.mako
+++ b/pyfr/solvers/navstokes/kernels/bcs/no-slp-isot-wall.mako
@@ -4,8 +4,8 @@
 
 <%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur, ploc, t'>
     ur[0] = ul[0];
-% for i, v in enumerate(c['v']):
-    ur[${i + 1}] = -ul[${i + 1}] + ${2*v}*ul[0];
+% for i, v in enumerate('uvw'[:ndims]):
+    ur[${i + 1}] = -ul[${i + 1}] + 2*${c[v]}*ul[0];
 % endfor
     ur[${nvars - 1}] = ${c['cpTw']/c['gamma']}*ur[0]
                      + 0.5*(1.0/ur[0])*${pyfr.dot('ur[{i}]', i=(1, ndims + 1))};
@@ -13,8 +13,8 @@
 
 <%pyfr:macro name='bc_ldg_state' params='ul, nl, ur, ploc, t'>
     ur[0] = ul[0];
-% for i, v in enumerate(c['v']):
-    ur[${i + 1}] = ${v}*ul[0];
+% for i, v in enumerate('uvw'[:ndims]):
+    ur[${i + 1}] = ${c[v]}*ul[0];
 % endfor
     ur[${nvars - 1}] = ${c['cpTw']/c['gamma']}*ur[0]
                      + 0.5*(1.0/ur[0])*${pyfr.dot('ur[{i}]', i=(1, ndims + 1))};


### PR DESCRIPTION
No-slip isothermal BC did not allow expressions for x,y,z. Changed the function for evaluating the BC options to be more consistent with the other BCs (_eval_opts to _exp_opts) which allow expressions. Isothermal BC mako file syntax for loop through 'uvw' changed as well.