### PR TITLE
Allow custom arguments in kernels

### DIFF
--- a/pyfr/backends/base/generator.py
+++ b/pyfr/backends/base/generator.py
@@ -112,8 +112,11 @@ class BaseKernelGenerator(object, metaclass=ABCMeta):
         return self.ndim, argn, argt
 
     def needs_ldim(self, arg):
-        return ((self.ndim == 2 and not arg.isbroadcast) or
-                (arg.ncdim > 0 and not arg.ismpi))
+        if arg.isbroadcast:
+            return ((self.ndim == 1 and arg.ncdim > 1) or
+                    (self.ndim == 2 and arg.ncdim > 0))
+        else:
+            return self.ndim == 2 or (arg.ncdim > 0 and not arg.ismpi)
 
     @abstractmethod
     def render(self):

--- a/pyfr/backends/base/kernels.py
+++ b/pyfr/backends/base/kernels.py
@@ -60,7 +60,7 @@ class BasePointwiseKernelProvider(BaseKernelProvider, metaclass=ABCMeta):
     kernel_generator_cls = None
 
     @memoize
-    def _render_kernel(self, name, mod, gargs, tplargs):
+    def _render_kernel(self, name, mod, extrns, tplargs):
         # Copy the provided argument list
         tplargs = dict(tplargs)
 
@@ -70,8 +70,8 @@ class BasePointwiseKernelProvider(BaseKernelProvider, metaclass=ABCMeta):
         # Macro definitions
         tplargs['_macros'] = {}
 
-        # Extra (global) kernel arguments dictionary
-        tplargs['_gargs'] = gargs
+        # External kernel arguments dictionary
+        tplargs['_extrns'] = extrns
 
         # Backchannel for obtaining kernel argument types
         tplargs['_kernel_argspecs'] = argspecs = {}
@@ -156,9 +156,9 @@ class BasePointwiseKernelProvider(BaseKernelProvider, metaclass=ABCMeta):
                 return
 
         # Generate the kernel providing method
-        def kernel_meth(self, tplargs, dims, gargs={}, **kwargs):
+        def kernel_meth(self, tplargs, dims, extrns={}, **kwargs):
             # Render the source of kernel
-            src, ndim, argn, argt = self._render_kernel(name, mod, gargs,
+            src, ndim, argn, argt = self._render_kernel(name, mod, extrns,
                                                         tplargs)
 
             # Compile the kernel

--- a/pyfr/solvers/aceuler/inters.py
+++ b/pyfr/solvers/aceuler/inters.py
@@ -51,9 +51,9 @@ class ACEulerBaseBCInters(BaseAdvectionBCInters):
 
         self.kernels['comm_flux'] = lambda: self._be.kernel(
             'bccflux', tplargs=tplargs, dims=[self.ninterfpts],
-            gargs=self._kglobal_args, ul=self._scal_lhs,
+            extrns=self._external_args, ul=self._scal_lhs,
             magnl=self._mag_pnorm_lhs, nl=self._norm_pnorm_lhs,
-            **self._kglobal_vals
+            **self._external_vals
         )
 
 

--- a/pyfr/solvers/aceuler/inters.py
+++ b/pyfr/solvers/aceuler/inters.py
@@ -50,8 +50,10 @@ class ACEulerBaseBCInters(BaseAdvectionBCInters):
                        c=self._tpl_c, bctype=self.type)
 
         self.kernels['comm_flux'] = lambda: self._be.kernel(
-            'bccflux', tplargs, dims=[self.ninterfpts], ul=self._scal_lhs,
-            magnl=self._mag_pnorm_lhs, nl=self._norm_pnorm_lhs
+            'bccflux', tplargs=tplargs, dims=[self.ninterfpts],
+            gargs=self._kglobal_args, ul=self._scal_lhs,
+            magnl=self._mag_pnorm_lhs, nl=self._norm_pnorm_lhs,
+            **self._kglobal_vals
         )
 
 

--- a/pyfr/solvers/aceuler/kernels/bccflux.mako
+++ b/pyfr/solvers/aceuler/kernels/bccflux.mako
@@ -8,12 +8,10 @@
 <%pyfr:kernel name='bccflux' ndim='1'
               ul='inout view fpdtype_t[${str(nvars)}]'
               nl='in fpdtype_t[${str(ndims)}]'
-              magnl='in fpdtype_t'
-              ploc='in fpdtype_t[${str(ndims)}]'
-              t='scalar fpdtype_t'>
+              magnl='in fpdtype_t'>
     // Compute the RHS
     fpdtype_t ur[${nvars}];
-    ${pyfr.expand('bc_rsolve_state', 'ul', 'nl', 'ur', 'ploc', 't')};
+    ${pyfr.expand('bc_rsolve_state', 'ul', 'nl', 'ur')};
 
     // Perform the Riemann solve
     fpdtype_t fn[${nvars}];

--- a/pyfr/solvers/aceuler/kernels/bcs/ac-char-riem-inv.mako
+++ b/pyfr/solvers/aceuler/kernels/bcs/ac-char-riem-inv.mako
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 
-<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur, ploc, t'>
+<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' externs='ploc, t'>
     fpdtype_t zeta = ${c['bc-ac-zeta']};
 
     fpdtype_t V_e = ${' + '.join('{0}*nl[{1}]'.format(c['uvw'[i]], i)

--- a/pyfr/solvers/aceuler/kernels/bcs/ac-in-fv.mako
+++ b/pyfr/solvers/aceuler/kernels/bcs/ac-in-fv.mako
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 
-<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur', externs='ploc, t'>
+<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' externs='ploc, t'>
     ur[0] = ul[0];
 
 % for i, v in enumerate('uvw'[:ndims]):

--- a/pyfr/solvers/aceuler/kernels/bcs/ac-in-fv.mako
+++ b/pyfr/solvers/aceuler/kernels/bcs/ac-in-fv.mako
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 
-<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur, ploc, t'>
+<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur', gparams='ploc, t'>
     ur[0] = ul[0];
 
 % for i, v in enumerate('uvw'[:ndims]):

--- a/pyfr/solvers/aceuler/kernels/bcs/ac-in-fv.mako
+++ b/pyfr/solvers/aceuler/kernels/bcs/ac-in-fv.mako
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 
-<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur', gparams='ploc, t'>
+<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur', externs='ploc, t'>
     ur[0] = ul[0];
 
 % for i, v in enumerate('uvw'[:ndims]):

--- a/pyfr/solvers/aceuler/kernels/bcs/ac-out-fp.mako
+++ b/pyfr/solvers/aceuler/kernels/bcs/ac-out-fp.mako
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 
-<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur, ploc, t'>
+<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' gparams='ploc, t'>
     ur[0] = ${c['p']};
 
 % for i, v in enumerate('uvw'[:ndims]):

--- a/pyfr/solvers/aceuler/kernels/bcs/ac-out-fp.mako
+++ b/pyfr/solvers/aceuler/kernels/bcs/ac-out-fp.mako
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 
-<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' gparams='ploc, t'>
+<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' externs='ploc, t'>
     ur[0] = ${c['p']};
 
 % for i, v in enumerate('uvw'[:ndims]):

--- a/pyfr/solvers/acnavstokes/inters.py
+++ b/pyfr/solvers/acnavstokes/inters.py
@@ -77,15 +77,16 @@ class ACNavierStokesBaseBCInters(BaseAdvectionDiffusionBCInters):
 
         self.kernels['con_u'] = lambda: self._be.kernel(
             'bcconu', tplargs=tplargs, dims=[self.ninterfpts],
-            gargs=self._kglobal_args, ulin=self._scal_lhs,
+            extrns=self._external_args, ulin=self._scal_lhs,
             ulout=self._vect_lhs, nlin=self._norm_pnorm_lhs,
-            **self._kglobal_vals
+            **self._external_vals
         )
         self.kernels['comm_flux'] = lambda: self._be.kernel(
             'bccflux', tplargs=tplargs, dims=[self.ninterfpts],
-            gargs=self._kglobal_args, ul=self._scal_lhs, gradul=self._vect_lhs,
-            magnl=self._mag_pnorm_lhs, nl=self._norm_pnorm_lhs,
-            **self._kglobal_vals
+            extrns=self._external_args, ul=self._scal_lhs,
+            gradul=self._vect_lhs, magnl=self._mag_pnorm_lhs,
+            nl=self._norm_pnorm_lhs,
+            **self._external_vals
         )
 
 

--- a/pyfr/solvers/acnavstokes/inters.py
+++ b/pyfr/solvers/acnavstokes/inters.py
@@ -77,14 +77,15 @@ class ACNavierStokesBaseBCInters(BaseAdvectionDiffusionBCInters):
 
         self.kernels['con_u'] = lambda: self._be.kernel(
             'bcconu', tplargs=tplargs, dims=[self.ninterfpts],
-            ulin=self._scal_lhs, ulout=self._vect_lhs,
-            nlin=self._norm_pnorm_lhs, ploc=self._ploc
+            gargs=self._kglobal_args, ulin=self._scal_lhs,
+            ulout=self._vect_lhs, nlin=self._norm_pnorm_lhs,
+            **self._kglobal_vals
         )
         self.kernels['comm_flux'] = lambda: self._be.kernel(
             'bccflux', tplargs=tplargs, dims=[self.ninterfpts],
-            ul=self._scal_lhs, gradul=self._vect_lhs,
+            gargs=self._kglobal_args, ul=self._scal_lhs, gradul=self._vect_lhs,
             magnl=self._mag_pnorm_lhs, nl=self._norm_pnorm_lhs,
-            ploc=self._ploc
+            **self._kglobal_vals
         )
 
 

--- a/pyfr/solvers/acnavstokes/kernels/bccflux.mako
+++ b/pyfr/solvers/acnavstokes/kernels/bccflux.mako
@@ -12,8 +12,6 @@
               ul='inout view fpdtype_t[${str(nvars)}]'
               gradul='in view fpdtype_t[${str(ndims)}][${str(nvars)}]'
               nl='in fpdtype_t[${str(ndims)}]'
-              magnl='in fpdtype_t'
-              ploc='in fpdtype_t[${str(ndims)}]'
-              t='scalar fpdtype_t'>
-    ${pyfr.expand('bc_common_flux_state', 'ul', 'gradul', 'nl', 'magnl', 'ploc', 't')};
+              magnl='in fpdtype_t'>
+    ${pyfr.expand('bc_common_flux_state', 'ul', 'gradul', 'nl', 'magnl')};
 </%pyfr:kernel>

--- a/pyfr/solvers/acnavstokes/kernels/bcconu.mako
+++ b/pyfr/solvers/acnavstokes/kernels/bcconu.mako
@@ -7,8 +7,6 @@
 <%pyfr:kernel name='bcconu' ndim='1'
               ulin='in view fpdtype_t[${str(nvars)}]'
               ulout='out view fpdtype_t[${str(nvars)}]'
-              nlin='in fpdtype_t[${str(ndims)}]'
-              ploc='in fpdtype_t[${str(ndims)}]'
-              t='scalar fpdtype_t'>
-    ${pyfr.expand('bc_ldg_state', 'ulin', 'nlin', 'ulout', 'ploc', 't')};
+              nlin='in fpdtype_t[${str(ndims)}]'>
+    ${pyfr.expand('bc_ldg_state', 'ulin', 'nlin', 'ulout')};
 </%pyfr:kernel>

--- a/pyfr/solvers/acnavstokes/kernels/bcs/ghost.mako
+++ b/pyfr/solvers/acnavstokes/kernels/bcs/ghost.mako
@@ -5,17 +5,17 @@
 
 <% tau = c['ldg-tau'] %>
 
-<%pyfr:macro name='bc_common_flux_state' params='ul, gradul, nl, magnl, ploc, t'>
+<%pyfr:macro name='bc_common_flux_state' params='ul, gradul, nl, magnl'>
     // Viscous states
     fpdtype_t ur[${nvars}], gradur[${ndims}][${nvars}];
-    ${pyfr.expand('bc_ldg_state', 'ul', 'nl', 'ur', 'ploc', 't')};
+    ${pyfr.expand('bc_ldg_state', 'ul', 'nl', 'ur')};
     ${pyfr.expand('bc_ldg_grad_state', 'ul', 'nl', 'gradul', 'gradur')};
 
     fpdtype_t fvr[${ndims}][${nvars}] = {{0}};
     ${pyfr.expand('viscous_flux_add', 'ur', 'gradur', 'fvr')};
 
     // Inviscid (Riemann solve) state
-    ${pyfr.expand('bc_rsolve_state', 'ul', 'nl', 'ur', 'ploc', 't')};
+    ${pyfr.expand('bc_rsolve_state', 'ul', 'nl', 'ur')};
 
     // Perform the Riemann solve
     fpdtype_t ficomm[${nvars}], fvcomm;

--- a/pyfr/solvers/acnavstokes/kernels/bcs/no-slp-wall.mako
+++ b/pyfr/solvers/acnavstokes/kernels/bcs/no-slp-wall.mako
@@ -2,14 +2,14 @@
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 <%include file='pyfr.solvers.acnavstokes.kernels.bcs.common'/>
 
-<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' gparams='ploc, t'>
+<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' externs='ploc, t'>
     ur[0] = ul[0];
 % for i, v in enumerate(c['v']):
     ur[${i + 1}] = -ul[${i + 1}] + ${2*v};
 % endfor
 </%pyfr:macro>
 
-<%pyfr:macro name='bc_ldg_state' params='ul, nl, ur' gparams='ploc, t'>
+<%pyfr:macro name='bc_ldg_state' params='ul, nl, ur' externs='ploc, t'>
     ur[0] = ul[0];
 % for i, v in enumerate(c['v']):
     ur[${i + 1}] = ${v};

--- a/pyfr/solvers/acnavstokes/kernels/bcs/no-slp-wall.mako
+++ b/pyfr/solvers/acnavstokes/kernels/bcs/no-slp-wall.mako
@@ -2,14 +2,14 @@
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 <%include file='pyfr.solvers.acnavstokes.kernels.bcs.common'/>
 
-<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur, ploc, t'>
+<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' gparams='ploc, t'>
     ur[0] = ul[0];
 % for i, v in enumerate(c['v']):
     ur[${i + 1}] = -ul[${i + 1}] + ${2*v};
 % endfor
 </%pyfr:macro>
 
-<%pyfr:macro name='bc_ldg_state' params='ul, nl, ur, ploc, t'>
+<%pyfr:macro name='bc_ldg_state' params='ul, nl, ur' gparams='ploc, t'>
     ur[0] = ul[0];
 % for i, v in enumerate(c['v']):
     ur[${i + 1}] = ${v};

--- a/pyfr/solvers/acnavstokes/kernels/bcs/slp-wall.mako
+++ b/pyfr/solvers/acnavstokes/kernels/bcs/slp-wall.mako
@@ -5,7 +5,7 @@
 <%include file='pyfr.solvers.acnavstokes.kernels.bcs.common'/>
 <%include file='pyfr.solvers.acnavstokes.kernels.flux'/>
 
-<%pyfr:macro name='bc_ldg_state' params='ul, nl, ur, ploc, t'>
+<%pyfr:macro name='bc_ldg_state' params='ul, nl, ur'>
     fpdtype_t nor = ${' + '.join('nl[{0}]*ul[{1}]'.format(i, i + 1)
                                  for i in range(ndims))};
     ur[0] = ul[0];
@@ -14,10 +14,10 @@
 % endfor
 </%pyfr:macro>
 
-<%pyfr:macro name='bc_common_flux_state' params='ul, gradul, nl, magnl, ploc, t'>
+<%pyfr:macro name='bc_common_flux_state' params='ul, gradul, nl, magnl'>
     // Ghost state r
     fpdtype_t ur[${nvars}];
-    ${pyfr.expand('bc_ldg_state', 'ul', 'nl', 'ur', 'ploc', 't')};
+    ${pyfr.expand('bc_ldg_state', 'ul', 'nl', 'ur')};
 
     // Perform the Riemann solve
     fpdtype_t ficomm[${nvars}];

--- a/pyfr/solvers/base/inters.py
+++ b/pyfr/solvers/base/inters.py
@@ -22,7 +22,7 @@ def get_opt_view_perm(interside, mat, elemap):
 class BaseInters(object):
     def __init__(self, be, lhs, elemap, cfg):
         self._be = be
-        self._elemap = elemap
+        self.elemap = elemap
         self.cfg = cfg
 
         # Get the number of dimensions and variables
@@ -49,6 +49,9 @@ class BaseInters(object):
         self._kglobal_args = {}
         self._kglobal_vals = {}
 
+    def prepare(self, t):
+        pass
+
     def _set_kernel_global(self, name, spec, value=None):
         self._kglobal_args[name] = spec
 
@@ -56,7 +59,7 @@ class BaseInters(object):
             self._kglobal_vals[name] = value
 
     def _const_mat(self, inter, meth):
-        m = _get_inter_objs(inter, meth, self._elemap)
+        m = _get_inter_objs(inter, meth, self.elemap)
 
         # Swizzle the dimensions and permute
         m = np.concatenate(m)
@@ -66,7 +69,7 @@ class BaseInters(object):
         return self._be.const_matrix(m)
 
     def _view(self, inter, meth, vshape=tuple()):
-        vm = _get_inter_objs(inter, meth, self._elemap)
+        vm = _get_inter_objs(inter, meth, self.elemap)
         vm = [np.concatenate(m)[self._perm] for m in zip(*vm)]
         return self._be.view(*vm, vshape=vshape)
 
@@ -77,7 +80,7 @@ class BaseInters(object):
         return self._view(inter, meth, (self.ndims, self.nvars))
 
     def _xchg_view(self, inter, meth, vshape=tuple()):
-        vm = _get_inter_objs(inter, meth, self._elemap)
+        vm = _get_inter_objs(inter, meth, self.elemap)
         vm = [np.concatenate(m)[self._perm] for m in zip(*vm)]
         return self._be.xchg_view(*vm, vshape=vshape)
 

--- a/pyfr/solvers/base/inters.py
+++ b/pyfr/solvers/base/inters.py
@@ -46,17 +46,17 @@ class BaseInters(object):
         self.kernels = {}
 
         # Global kernel arguments
-        self._kglobal_args = {}
-        self._kglobal_vals = {}
+        self._external_args = {}
+        self._external_vals = {}
 
     def prepare(self, t):
         pass
 
-    def _set_kernel_global(self, name, spec, value=None):
-        self._kglobal_args[name] = spec
+    def _set_external(self, name, spec, value=None):
+        self._external_args[name] = spec
 
         if value is not None:
-            self._kglobal_vals[name] = value
+            self._external_vals[name] = value
 
     def _const_mat(self, inter, meth):
         m = _get_inter_objs(inter, meth, self.elemap)

--- a/pyfr/solvers/base/inters.py
+++ b/pyfr/solvers/base/inters.py
@@ -45,6 +45,16 @@ class BaseInters(object):
         # Kernels we provide
         self.kernels = {}
 
+        # Global kernel arguments
+        self._kglobal_args = {}
+        self._kglobal_vals = {}
+
+    def _set_kernel_global(self, name, spec, value=None):
+        self._kglobal_args[name] = spec
+
+        if value is not None:
+            self._kglobal_vals[name] = value
+
     def _const_mat(self, inter, meth):
         m = _get_inter_objs(inter, meth, self._elemap)
 

--- a/pyfr/solvers/base/system.py
+++ b/pyfr/solvers/base/system.py
@@ -65,6 +65,10 @@ class BaseSystem(object, metaclass=ABCMeta):
         self._gen_kernels(eles, int_inters, mpi_inters, bc_inters)
         backend.commit()
 
+        # Save the BC interfaces, but delete the memory-intensive elemap
+        self._bc_inters = bc_inters
+        del bc_inters.elemap
+
     def _load_eles(self, rallocs, mesh, initsoln, nregs, nonce):
         basismap = {b.name: b for b in subclasses(BaseShape, just_leaf=True)}
 

--- a/pyfr/solvers/baseadvec/inters.py
+++ b/pyfr/solvers/baseadvec/inters.py
@@ -83,7 +83,7 @@ class BaseAdvectionBCInters(BaseInters):
         self._norm_pnorm_lhs = const_mat(lhs, 'get_norm_pnorms_for_inter')
 
         # Make the simulation time available inside kernels
-        self._set_kernel_global('t', 'scalar fpdtype_t')
+        self._set_external('t', 'scalar fpdtype_t')
 
     def _eval_opts(self, opts, default=None):
         # Boundary conditions, much like initial conditions, can be
@@ -114,10 +114,10 @@ class BaseAdvectionBCInters(BaseInters):
                 exprs[k] = cfg.getexpr(sect, k, subs=subs)
 
         if (any('ploc' in ex for ex in exprs.values()) and
-            'ploc' not in self._kglobal_args):
+            'ploc' not in self._external_args):
             spec = 'in fpdtype_t[{0}]'.format(self.ndims)
             value = self._const_mat(lhs, 'get_ploc_for_inter')
 
-            self._set_kernel_global('ploc', spec, value=value)
+            self._set_external('ploc', spec, value=value)
 
         return exprs

--- a/pyfr/solvers/baseadvec/inters.py
+++ b/pyfr/solvers/baseadvec/inters.py
@@ -27,7 +27,7 @@ class BaseAdvectionIntInters(BaseInters):
         # Arbitrarily, take the permutation which results in an optimal
         # memory access pattern for the LHS of the interface
         self._perm = get_opt_view_perm(lhs, 'get_scal_fpts_for_inter',
-                                       self._elemap)
+                                       self.elemap)
 
 
 class BaseAdvectionMPIInters(BaseInters):

--- a/pyfr/solvers/baseadvec/system.py
+++ b/pyfr/solvers/baseadvec/system.py
@@ -11,6 +11,8 @@ class BaseAdvectionSystem(BaseSystem):
         q1, q2 = self._queues
         kernels = self._kernels
 
+        self._bc_inters.prepare(t)
+
         self.eles_scal_upts_inb.active = uinbank
         self.eles_scal_upts_outb.active = foutbank
 

--- a/pyfr/solvers/baseadvecdiff/inters.py
+++ b/pyfr/solvers/baseadvecdiff/inters.py
@@ -33,7 +33,7 @@ class BaseAdvectionDiffusionIntInters(BaseAdvectionIntInters):
 
         # Compute the relevant permutation
         self._perm = get_opt_view_perm(side, 'get_scal_fpts_for_inter',
-                                       self._elemap)
+                                       self.elemap)
 
 
 class BaseAdvectionDiffusionMPIInters(BaseAdvectionMPIInters):

--- a/pyfr/solvers/baseadvecdiff/system.py
+++ b/pyfr/solvers/baseadvecdiff/system.py
@@ -9,6 +9,8 @@ class BaseAdvectionDiffusionSystem(BaseAdvectionSystem):
         q1, q2 = self._queues
         kernels = self._kernels
 
+        self._bc_inters.prepare(t)
+
         self.eles_scal_upts_inb.active = uinbank
         self.eles_scal_upts_outb.active = foutbank
 

--- a/pyfr/solvers/euler/inters.py
+++ b/pyfr/solvers/euler/inters.py
@@ -51,9 +51,9 @@ class EulerBaseBCInters(BaseAdvectionBCInters):
 
         self.kernels['comm_flux'] = lambda: self._be.kernel(
             'bccflux', tplargs=tplargs, dims=[self.ninterfpts],
-            gargs=self._kglobal_args, ul=self._scal_lhs,
+            extrns=self._external_args, ul=self._scal_lhs,
             magnl=self._mag_pnorm_lhs, nl=self._norm_pnorm_lhs,
-            **self._kglobal_vals
+            **self._external_vals
         )
 
 

--- a/pyfr/solvers/euler/inters.py
+++ b/pyfr/solvers/euler/inters.py
@@ -50,9 +50,10 @@ class EulerBaseBCInters(BaseAdvectionBCInters):
                        c=self._tpl_c, bctype=self.type)
 
         self.kernels['comm_flux'] = lambda: self._be.kernel(
-            'bccflux', tplargs, dims=[self.ninterfpts], ul=self._scal_lhs,
+            'bccflux', tplargs=tplargs, dims=[self.ninterfpts],
+            gargs=self._kglobal_args, ul=self._scal_lhs,
             magnl=self._mag_pnorm_lhs, nl=self._norm_pnorm_lhs,
-            ploc=self._ploc
+            **self._kglobal_vals
         )
 
 

--- a/pyfr/solvers/euler/kernels/bccflux.mako
+++ b/pyfr/solvers/euler/kernels/bccflux.mako
@@ -8,12 +8,10 @@
 <%pyfr:kernel name='bccflux' ndim='1'
               ul='inout view fpdtype_t[${str(nvars)}]'
               nl='in fpdtype_t[${str(ndims)}]'
-              magnl='in fpdtype_t'
-              ploc='in fpdtype_t[${str(ndims)}]'
-              t='scalar fpdtype_t'>
+              magnl='in fpdtype_t'>
     // Compute the RHS
     fpdtype_t ur[${nvars}];
-    ${pyfr.expand('bc_rsolve_state', 'ul', 'nl', 'ur', 'ploc', 't')};
+    ${pyfr.expand('bc_rsolve_state', 'ul', 'nl', 'ur')};
 
     // Perform the Riemann solve
     fpdtype_t fn[${nvars}];

--- a/pyfr/solvers/euler/kernels/bcs/char-riem-inv.mako
+++ b/pyfr/solvers/euler/kernels/bcs/char-riem-inv.mako
@@ -4,7 +4,7 @@
 <% gmo = c['gamma'] - 1.0 %>
 <% gamma = c['gamma'] %>
 
-<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur, ploc, t'>
+<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' gparams='ploc, t'>
     fpdtype_t cs = sqrt(${gamma}*${c['p']}/${c['rho']});
     fpdtype_t s = ${c['p']}*pow(${c['rho']}, -${gamma});
     fpdtype_t ratio = cs*${2.0/gmo};

--- a/pyfr/solvers/euler/kernels/bcs/char-riem-inv.mako
+++ b/pyfr/solvers/euler/kernels/bcs/char-riem-inv.mako
@@ -4,7 +4,7 @@
 <% gmo = c['gamma'] - 1.0 %>
 <% gamma = c['gamma'] %>
 
-<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' gparams='ploc, t'>
+<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' externs='ploc, t'>
     fpdtype_t cs = sqrt(${gamma}*${c['p']}/${c['rho']});
     fpdtype_t s = ${c['p']}*pow(${c['rho']}, -${gamma});
     fpdtype_t ratio = cs*${2.0/gmo};

--- a/pyfr/solvers/euler/kernels/bcs/slp-adia-wall.mako
+++ b/pyfr/solvers/euler/kernels/bcs/slp-adia-wall.mako
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 
-<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' gparams='ploc, t'>
+<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' externs='ploc, t'>
     fpdtype_t nor = ${' + '.join('ul[{1}]*nl[{0}]'.format(i, i + 1)
                                  for i in range(ndims))};
     ur[0] = ul[0];

--- a/pyfr/solvers/euler/kernels/bcs/slp-adia-wall.mako
+++ b/pyfr/solvers/euler/kernels/bcs/slp-adia-wall.mako
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 
-<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur, ploc, t'>
+<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' gparams='ploc, t'>
     fpdtype_t nor = ${' + '.join('ul[{1}]*nl[{0}]'.format(i, i + 1)
                                  for i in range(ndims))};
     ur[0] = ul[0];

--- a/pyfr/solvers/euler/kernels/bcs/sup-in-fa.mako
+++ b/pyfr/solvers/euler/kernels/bcs/sup-in-fa.mako
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 
-<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' gparams='ploc, t'>
+<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' externs='ploc, t'>
     ur[0] = ${c['rho']};
 % for i, v in enumerate('uvw'[:ndims]):
     ur[${i + 1}] = (${c['rho']})*(${c[v]});

--- a/pyfr/solvers/euler/kernels/bcs/sup-in-fa.mako
+++ b/pyfr/solvers/euler/kernels/bcs/sup-in-fa.mako
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 
-<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur, ploc, t'>
+<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' gparams='ploc, t'>
     ur[0] = ${c['rho']};
 % for i, v in enumerate('uvw'[:ndims]):
     ur[${i + 1}] = (${c['rho']})*(${c[v]});

--- a/pyfr/solvers/navstokes/inters.py
+++ b/pyfr/solvers/navstokes/inters.py
@@ -90,14 +90,16 @@ class NavierStokesBaseBCInters(BaseAdvectionDiffusionBCInters):
 
         self.kernels['con_u'] = lambda: be.kernel(
             'bcconu', tplargs=tplargs, dims=[self.ninterfpts],
-            ulin=self._scal_lhs, ulout=self._vect_lhs,
-            nlin=self._norm_pnorm_lhs, ploc=self._ploc
+            gargs=self._kglobal_args, ulin=self._scal_lhs,
+            ulout=self._vect_lhs, nlin=self._norm_pnorm_lhs,
+            **self._kglobal_vals
         )
         self.kernels['comm_flux'] = lambda: be.kernel(
             'bccflux', tplargs=tplargs, dims=[self.ninterfpts],
-            ul=self._scal_lhs, gradul=self._vect_lhs,
-            magnl=self._mag_pnorm_lhs, nl=self._norm_pnorm_lhs,
-            ploc=self._ploc, artviscl=self._artvisc_lhs
+            gargs=self._kglobal_args, ul=self._scal_lhs,
+            gradul=self._vect_lhs, magnl=self._mag_pnorm_lhs,
+            nl=self._norm_pnorm_lhs, artviscl=self._artvisc_lhs,
+            **self._kglobal_vals
         )
 
 

--- a/pyfr/solvers/navstokes/inters.py
+++ b/pyfr/solvers/navstokes/inters.py
@@ -90,16 +90,16 @@ class NavierStokesBaseBCInters(BaseAdvectionDiffusionBCInters):
 
         self.kernels['con_u'] = lambda: be.kernel(
             'bcconu', tplargs=tplargs, dims=[self.ninterfpts],
-            gargs=self._kglobal_args, ulin=self._scal_lhs,
+            extrns=self._external_args, ulin=self._scal_lhs,
             ulout=self._vect_lhs, nlin=self._norm_pnorm_lhs,
-            **self._kglobal_vals
+            **self._external_vals
         )
         self.kernels['comm_flux'] = lambda: be.kernel(
             'bccflux', tplargs=tplargs, dims=[self.ninterfpts],
-            gargs=self._kglobal_args, ul=self._scal_lhs,
+            extrns=self._external_args, ul=self._scal_lhs,
             gradul=self._vect_lhs, magnl=self._mag_pnorm_lhs,
             nl=self._norm_pnorm_lhs, artviscl=self._artvisc_lhs,
-            **self._kglobal_vals
+            **self._external_vals
         )
 
 

--- a/pyfr/solvers/navstokes/kernels/bccflux.mako
+++ b/pyfr/solvers/navstokes/kernels/bccflux.mako
@@ -13,8 +13,6 @@
               gradul='in view fpdtype_t[${str(ndims)}][${str(nvars)}]'
               artviscl='in view fpdtype_t'
               nl='in fpdtype_t[${str(ndims)}]'
-              magnl='in fpdtype_t'
-              ploc='in fpdtype_t[${str(ndims)}]'
-              t='scalar fpdtype_t'>
-    ${pyfr.expand('bc_common_flux_state', 'ul', 'gradul', 'artviscl', 'nl', 'magnl', 'ploc', 't')};
+              magnl='in fpdtype_t'>
+    ${pyfr.expand('bc_common_flux_state', 'ul', 'gradul', 'artviscl', 'nl', 'magnl')};
 </%pyfr:kernel>

--- a/pyfr/solvers/navstokes/kernels/bcconu.mako
+++ b/pyfr/solvers/navstokes/kernels/bcconu.mako
@@ -7,8 +7,6 @@
 <%pyfr:kernel name='bcconu' ndim='1'
               ulin='in view fpdtype_t[${str(nvars)}]'
               ulout='out view fpdtype_t[${str(nvars)}]'
-              nlin='in fpdtype_t[${str(ndims)}]'
-              ploc='in fpdtype_t[${str(ndims)}]'
-              t='scalar fpdtype_t'>
-    ${pyfr.expand('bc_ldg_state', 'ulin', 'nlin', 'ulout', 'ploc', 't')};
+              nlin='in fpdtype_t[${str(ndims)}]'>
+    ${pyfr.expand('bc_ldg_state', 'ulin', 'nlin', 'ulout')};
 </%pyfr:kernel>

--- a/pyfr/solvers/navstokes/kernels/bcs/ghost.mako
+++ b/pyfr/solvers/navstokes/kernels/bcs/ghost.mako
@@ -6,10 +6,10 @@
 
 <% tau = c['ldg-tau'] %>
 
-<%pyfr:macro name='bc_common_flux_state' params='ul, gradul, artviscl, nl, magnl, ploc, t'>
+<%pyfr:macro name='bc_common_flux_state' params='ul, gradul, artviscl, nl, magnl'>
     // Viscous states
     fpdtype_t ur[${nvars}], gradur[${ndims}][${nvars}];
-    ${pyfr.expand('bc_ldg_state', 'ul', 'nl', 'ur', 'ploc', 't')};
+    ${pyfr.expand('bc_ldg_state', 'ul', 'nl', 'ur')};
     ${pyfr.expand('bc_ldg_grad_state', 'ul', 'nl', 'gradul', 'gradur')};
 
     fpdtype_t fvr[${ndims}][${nvars}] = {{0}};
@@ -17,7 +17,7 @@
     ${pyfr.expand('artificial_viscosity_add', 'gradur', 'fvr', 'artviscl')};
 
     // Inviscid (Riemann solve) state
-    ${pyfr.expand('bc_rsolve_state', 'ul', 'nl', 'ur', 'ploc', 't')};
+    ${pyfr.expand('bc_rsolve_state', 'ul', 'nl', 'ur')};
 
     // Perform the Riemann solve
     fpdtype_t ficomm[${nvars}], fvcomm;

--- a/pyfr/solvers/navstokes/kernels/bcs/no-slp-adia-wall.mako
+++ b/pyfr/solvers/navstokes/kernels/bcs/no-slp-adia-wall.mako
@@ -2,7 +2,7 @@
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 <%include file='pyfr.solvers.navstokes.kernels.bcs.common'/>
 
-<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur, ploc, t'>
+<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' gparams='ploc, t'>
     ur[0] = ul[0];
 % for i in range(ndims):
     ur[${i + 1}] = -ul[${i + 1}];
@@ -10,7 +10,7 @@
     ur[${nvars - 1}] = ul[${nvars - 1}];
 </%pyfr:macro>
 
-<%pyfr:macro name='bc_ldg_state' params='ul, nl, ur, ploc, t'>
+<%pyfr:macro name='bc_ldg_state' params='ul, nl, ur' gparams='ploc, t'>
     ur[0] = ul[0];
 % for i in range(ndims):
     ur[${i + 1}] = 0.0;

--- a/pyfr/solvers/navstokes/kernels/bcs/no-slp-adia-wall.mako
+++ b/pyfr/solvers/navstokes/kernels/bcs/no-slp-adia-wall.mako
@@ -2,7 +2,7 @@
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 <%include file='pyfr.solvers.navstokes.kernels.bcs.common'/>
 
-<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' gparams='ploc, t'>
+<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' externs='ploc, t'>
     ur[0] = ul[0];
 % for i in range(ndims):
     ur[${i + 1}] = -ul[${i + 1}];
@@ -10,7 +10,7 @@
     ur[${nvars - 1}] = ul[${nvars - 1}];
 </%pyfr:macro>
 
-<%pyfr:macro name='bc_ldg_state' params='ul, nl, ur' gparams='ploc, t'>
+<%pyfr:macro name='bc_ldg_state' params='ul, nl, ur' externs='ploc, t'>
     ur[0] = ul[0];
 % for i in range(ndims):
     ur[${i + 1}] = 0.0;

--- a/pyfr/solvers/navstokes/kernels/bcs/no-slp-isot-wall.mako
+++ b/pyfr/solvers/navstokes/kernels/bcs/no-slp-isot-wall.mako
@@ -2,7 +2,7 @@
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 <%include file='pyfr.solvers.navstokes.kernels.bcs.common'/>
 
-<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' gparams='ploc, t'>
+<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' externs='ploc, t'>
     ur[0] = ul[0];
 % for i, v in enumerate('uvw'[:ndims]):
     ur[${i + 1}] = -ul[${i + 1}] + 2*${c[v]}*ul[0];
@@ -11,7 +11,7 @@
                      + 0.5*(1.0/ur[0])*${pyfr.dot('ur[{i}]', i=(1, ndims + 1))};
 </%pyfr:macro>
 
-<%pyfr:macro name='bc_ldg_state' params='ul, nl, ur' gparams='ploc, t'>
+<%pyfr:macro name='bc_ldg_state' params='ul, nl, ur' externs='ploc, t'>
     ur[0] = ul[0];
 % for i, v in enumerate('uvw'[:ndims]):
     ur[${i + 1}] = ${c[v]}*ul[0];

--- a/pyfr/solvers/navstokes/kernels/bcs/no-slp-isot-wall.mako
+++ b/pyfr/solvers/navstokes/kernels/bcs/no-slp-isot-wall.mako
@@ -2,7 +2,7 @@
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 <%include file='pyfr.solvers.navstokes.kernels.bcs.common'/>
 
-<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur, ploc, t'>
+<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' gparams='ploc, t'>
     ur[0] = ul[0];
 % for i, v in enumerate('uvw'[:ndims]):
     ur[${i + 1}] = -ul[${i + 1}] + 2*${c[v]}*ul[0];
@@ -11,7 +11,7 @@
                      + 0.5*(1.0/ur[0])*${pyfr.dot('ur[{i}]', i=(1, ndims + 1))};
 </%pyfr:macro>
 
-<%pyfr:macro name='bc_ldg_state' params='ul, nl, ur, ploc, t'>
+<%pyfr:macro name='bc_ldg_state' params='ul, nl, ur' gparams='ploc, t'>
     ur[0] = ul[0];
 % for i, v in enumerate('uvw'[:ndims]):
     ur[${i + 1}] = ${c[v]}*ul[0];

--- a/pyfr/solvers/navstokes/kernels/bcs/slp-adia-wall.mako
+++ b/pyfr/solvers/navstokes/kernels/bcs/slp-adia-wall.mako
@@ -5,7 +5,7 @@
 <%include file='pyfr.solvers.navstokes.kernels.bcs.common'/>
 <%include file='pyfr.solvers.navstokes.kernels.flux'/>
 
-<%pyfr:macro name='bc_ldg_state' params='ul, nl, ur, ploc, t'>
+<%pyfr:macro name='bc_ldg_state' params='ul, nl, ur'>
     fpdtype_t nor = ${' + '.join('ul[{1}]*nl[{0}]'.format(i, i + 1)
                                  for i in range(ndims))};
     ur[0] = ul[0];
@@ -15,10 +15,10 @@
     ur[${nvars - 1}] = ul[${nvars - 1}];
 </%pyfr:macro>
 
-<%pyfr:macro name='bc_common_flux_state' params='ul, gradul, artviscl, nl, magnl, ploc, t'>
+<%pyfr:macro name='bc_common_flux_state' params='ul, gradul, artviscl, nl, magnl'>
     // Ghost state r
     fpdtype_t ur[${nvars}];
-    ${pyfr.expand('bc_ldg_state', 'ul', 'nl', 'ur', 'ploc', 't')};
+    ${pyfr.expand('bc_ldg_state', 'ul', 'nl', 'ur')};
 
     // Perform the Riemann solve
     fpdtype_t ficomm[${nvars}];

--- a/pyfr/solvers/navstokes/kernels/bcs/sub-in-frv.mako
+++ b/pyfr/solvers/navstokes/kernels/bcs/sub-in-frv.mako
@@ -2,7 +2,7 @@
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 <%include file='pyfr.solvers.navstokes.kernels.bcs.common'/>
 
-<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' gparams='ploc, t'>
+<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' externs='ploc, t'>
     ur[0] = ${c['rho']};
 % for i, v in enumerate('uvw'[:ndims]):
     ur[${i + 1}] = (${c['rho']}) * (${c[v]});

--- a/pyfr/solvers/navstokes/kernels/bcs/sub-in-frv.mako
+++ b/pyfr/solvers/navstokes/kernels/bcs/sub-in-frv.mako
@@ -2,7 +2,7 @@
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 <%include file='pyfr.solvers.navstokes.kernels.bcs.common'/>
 
-<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur, ploc, t'>
+<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' gparams='ploc, t'>
     ur[0] = ${c['rho']};
 % for i, v in enumerate('uvw'[:ndims]):
     ur[${i + 1}] = (${c['rho']}) * (${c[v]});

--- a/pyfr/solvers/navstokes/kernels/bcs/sub-in-ftpttang.mako
+++ b/pyfr/solvers/navstokes/kernels/bcs/sub-in-ftpttang.mako
@@ -2,7 +2,7 @@
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 <%include file='pyfr.solvers.navstokes.kernels.bcs.common'/>
 
-<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur, ploc, t'>
+<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' gparams='ploc, t'>
     fpdtype_t pl = ${c['gamma'] - 1.0}*(ul[${nvars - 1}]
                  - (0.5/ul[0])*${pyfr.dot('ul[{i}]', i=(1, ndims + 1))});
     fpdtype_t udotu = ${2.0*c['cpTt']}*(1.0

--- a/pyfr/solvers/navstokes/kernels/bcs/sub-in-ftpttang.mako
+++ b/pyfr/solvers/navstokes/kernels/bcs/sub-in-ftpttang.mako
@@ -2,7 +2,7 @@
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 <%include file='pyfr.solvers.navstokes.kernels.bcs.common'/>
 
-<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' gparams='ploc, t'>
+<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' externs='ploc, t'>
     fpdtype_t pl = ${c['gamma'] - 1.0}*(ul[${nvars - 1}]
                  - (0.5/ul[0])*${pyfr.dot('ul[{i}]', i=(1, ndims + 1))});
     fpdtype_t udotu = ${2.0*c['cpTt']}*(1.0

--- a/pyfr/solvers/navstokes/kernels/bcs/sub-out-fp.mako
+++ b/pyfr/solvers/navstokes/kernels/bcs/sub-out-fp.mako
@@ -2,7 +2,7 @@
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 <%include file='pyfr.solvers.navstokes.kernels.bcs.common'/>
 
-<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' gparams='ploc, t'>
+<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' externs='ploc, t'>
 % for i in range(nvars - 1):
     ur[${i}] = ul[${i}];
 % endfor

--- a/pyfr/solvers/navstokes/kernels/bcs/sub-out-fp.mako
+++ b/pyfr/solvers/navstokes/kernels/bcs/sub-out-fp.mako
@@ -2,7 +2,7 @@
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 <%include file='pyfr.solvers.navstokes.kernels.bcs.common'/>
 
-<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur, ploc, t'>
+<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' gparams='ploc, t'>
 % for i in range(nvars - 1):
     ur[${i}] = ul[${i}];
 % endfor

--- a/pyfr/solvers/navstokes/kernels/bcs/sup-out-fn.mako
+++ b/pyfr/solvers/navstokes/kernels/bcs/sup-out-fn.mako
@@ -2,7 +2,7 @@
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 <%include file='pyfr.solvers.navstokes.kernels.bcs.common'/>
 
-<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur, ploc, t'>
+<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' gparams='ploc, t'>
 % for i in range(nvars):
     ur[${i}] = ul[${i}];
 % endfor

--- a/pyfr/solvers/navstokes/kernels/bcs/sup-out-fn.mako
+++ b/pyfr/solvers/navstokes/kernels/bcs/sup-out-fn.mako
@@ -2,7 +2,7 @@
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 <%include file='pyfr.solvers.navstokes.kernels.bcs.common'/>
 
-<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' gparams='ploc, t'>
+<%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' externs='ploc, t'>
 % for i in range(nvars):
     ur[${i}] = ul[${i}];
 % endfor

--- a/pyfr/util.py
+++ b/pyfr/util.py
@@ -45,6 +45,10 @@ class proxylist(list):
         for x in self:
             setattr(x, attr, val)
 
+    def __delattr__(self, attr):
+        for x in self:
+            delattr(x, attr)
+
     def __call__(self, *args, **kwargs):
         return proxylist(x(*args, **kwargs) for x in self)
 

--- a/pyfr/util.py
+++ b/pyfr/util.py
@@ -182,3 +182,14 @@ def rm(path):
 
 def mv(src, dst):
     shutil.move(src, dst)
+
+
+def match_paired_paren(delim, n=5):
+    open, close = delim
+    ocset = '[^{1}{0}]'.format(open, close)
+
+    lft = r'{0}*?(?:\{1}'.format(ocset, open)
+    mid = r'{0}*?'.format(ocset)
+    rgt = r'\{1}{0}*?)*?'.format(ocset, close)
+
+    return lft*n + mid + rgt*n


### PR DESCRIPTION
This provides a means by which kernels can register extra arguments in the form of external variables which are automatically passed down through any intermediate kernels.  This simplifies some existing code related to physical locations and time steps, and allows for the implementation of additional boundary conditions.

Finally, some indexing requirements in the DSL have also been relaxed such that it is now possible to use real for loops inside of kernels.